### PR TITLE
fix(bval): Handle trailing whitespace without newlines

### DIFF
--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -159,7 +159,7 @@ export async function readFileTree(rootPath: string): Promise<FileTree> {
     )
     ignore.add(await readBidsIgnore(ignoreFile))
   } catch (err) {
-    if (err && typeof err === 'object' && !('code' in err && err.code !== 'ENOENT')) {
+    if (err && typeof err === 'object' && !('code' in err && err.code === 'ENOENT')) {
       logger.error(`Failed to read '.bidsignore' file with the following error:\n${err}`)
     }
   }

--- a/src/files/dwi.test.ts
+++ b/src/files/dwi.test.ts
@@ -1,0 +1,35 @@
+import { assertEquals } from '@std/assert'
+
+import { parseBvalBvec } from './dwi.ts'
+
+Deno.test('Test bval/bvec parsing', async (t) => {
+  await t.step('Load 3 bvals', async () => {
+    const bvals = parseBvalBvec('0 1 2 \n')  // Typically ends with " \n"
+    assertEquals(bvals, [['0', '1', '2']])
+  })
+  await t.step('Load 3 bvals - missing newline', async () => {
+    const bvals = parseBvalBvec('0 1 2 ')
+    assertEquals(bvals, [['0', '1', '2']])
+  })
+  await t.step('Load 3 bvals - no spaces', async () => {
+    const bvals = parseBvalBvec('0 1 2')
+    assertEquals(bvals, [['0', '1', '2']])
+  })
+  await t.step('Load 3 bvecs', async () => {
+    const bvecs = parseBvalBvec('0 1 2 \n0 1 2 \n0 1 2 \n')
+    assertEquals(bvecs, [['0', '1', '2'], ['0', '1', '2'], ['0', '1', '2']])
+  })
+  await t.step('Load 3 bvals - missing newline', async () => {
+    const bvecs = parseBvalBvec('0 1 2 \n0 1 2 \n0 1 2 ')
+    assertEquals(bvecs, [['0', '1', '2'], ['0', '1', '2'], ['0', '1', '2']])
+  })
+  await t.step('Load 3 bvals - no spaces', async () => {
+    const bvecs = parseBvalBvec('0 1 2\n0 1 2\n0 1 2\n')
+    assertEquals(bvecs, [['0', '1', '2'], ['0', '1', '2'], ['0', '1', '2']])
+  })
+  await t.step('Load 3 bvals - no spaces, missing newline', async () => {
+    const bvecs = parseBvalBvec('0 1 2\n0 1 2\n0 1 2')
+    assertEquals(bvecs, [['0', '1', '2'], ['0', '1', '2'], ['0', '1', '2']])
+  })
+})
+

--- a/src/files/dwi.ts
+++ b/src/files/dwi.ts
@@ -10,7 +10,7 @@ export function parseBvalBvec(contents: string): string[][] {
   // BVAL files are a single row of numbers, and may contain
   // trailing whitespace
   return normalizeEOL(contents)
-    .split(/\s*\n/) // Split on newlines, ignoring trailing whitespace
+    .split(/\n/) // Split on newlines
     .filter((x) => x.match(/\S/)) // Remove empty lines
-    .map((row) => row.split(/\s+/))
+    .map((row) => row.trimEnd().split(/\s+/)) // Split on whitespace, ignoring trailing
 }


### PR DESCRIPTION
Fixes #9, adds a test that fails thus (if we revert the second commit):

```
Test bval/bvec parsing ... Load 3 bvals - missing newline => ./src/files/dwi.test.ts:10:11
error: AssertionError: Values are not equal.


    [Diff] Actual / Expected


    [
      [
        "0",
        "1",
        "2",
-       "",
      ],
    ]

  throw new AssertionError(message);
        ^
    at assertEquals (https://jsr.io/@std/assert/1.0.7/equals.ts:51:9)
    at file:///home/chris/Projects/bids/validator/src/files/dwi.test.ts:12:5
    at innerWrapped (ext:cli/40_test.js:191:11)
    at exitSanitizer (ext:cli/40_test.js:107:33)
    at Object.outerWrapped [as fn] (ext:cli/40_test.js:134:20)
    at TestContext.step (ext:cli/40_test.js:492:37)
    at file:///home/chris/Projects/bids/validator/src/files/dwi.test.ts:10:11

Test bval/bvec parsing ... Load 3 bvals - missing newline => ./src/files/dwi.test.ts:22:11
error: AssertionError: Values are not equal.


    [Diff] Actual / Expected


    [
      [
        "0",
        "1",
        "2",
      ],
      [
        "0",
        "1",
        "2",
      ],
      [
        "0",
        "1",
        "2",
-       "",
      ],
    ]

  throw new AssertionError(message);
        ^
    at assertEquals (https://jsr.io/@std/assert/1.0.7/equals.ts:51:9)
    at file:///home/chris/Projects/bids/validator/src/files/dwi.test.ts:24:5
    at innerWrapped (ext:cli/40_test.js:191:11)
    at exitSanitizer (ext:cli/40_test.js:107:33)
    at Object.outerWrapped [as fn] (ext:cli/40_test.js:134:20)
    at TestContext.step (ext:cli/40_test.js:492:37)
    at file:///home/chris/Projects/bids/validator/src/files/dwi.test.ts:22:11

 FAILURES

Test bval/bvec parsing ... Load 3 bvals - missing newline => ./src/files/dwi.test.ts:10:11
Test bval/bvec parsing ... Load 3 bvals - missing newline => ./src/files/dwi.test.ts:22:11

FAILED | 47 passed (652 steps) | 1 failed (2 steps) (21s)

error: Test failed
```