### PR TITLE
chore/doc: Revert main to stable schema, update docs to explain branching

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -102,6 +102,65 @@ consider:
    - first checkout your main: `git checkout main`
    - then run: `git reset --hard upstream/main`
 
+## Developing for the validator
+
+When proposing a feature or bug fix, you must decide what branch you will target:
+`main` or `dev`.
+In most cases, you will want `main`, but read below to understand the purposes of
+the two branches.
+
+### Branching policy
+
+The BIDS Validator's `main` branch tracks the most recent release version of the specification:
+<https://bids-specification.readthedocs.io/en/stable/>.
+Pull requests made against the `main` branch should implement features or fix bugs in a way
+that preserves consistency with the stable specification.
+
+The `dev` branch is for features that are not yet in the released version of the BIDS
+specification.
+The purpose of this branch is to verify that proposed rules can be validated and
+provide users with preview access to upcoming changes to the validator, increasing the chances
+of catching issues with the specification or the validator, prior to release.
+Changes to the `dev` branch may be backed out at any time.
+
+### How to prepare a pull request for your target branch
+
+If you're going to target `main`, then start as follows:
+
+```console
+git fetch upstream
+git switch -c feat/short-desc upstream/main
+```
+
+This will create a new branch named `feat/short-desc`
+(use `fix/...` for bug-fix branches, `doc/...` for documentation, etc.) starting
+from the current state of the `main` branch on the `upstream` remote.
+Instead of `short-desc`, use a few words to make the content of your branch
+easily identifiable.
+
+Once ready
+
+```console
+git push -u origin feat/short-desc
+```
+
+GitHub will give you a link, such as
+<https://github.com/bids-standard/bids-validator/compare/master...username:bids-validator:feat/short-desc?expand=1>.
+Follow that link to create a pull request.
+
+While you are creating the pull request, verify that the base branch is set to `main`.
+
+For `dev`, the process is identical:
+
+```console
+git fetch upstream
+git switch -c feat/short-desc upstream/dev
+# Add your feature
+git push -u origin feat/short-desc
+```
+
+Open PR, set base branch to `dev`.
+
 [link_git]: https://git-scm.com/
 [link_handbook]: https://guides.github.com/introduction/git-handbook/
 [link_swc_intro]: http://swcarpentry.github.io/git-novice/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -104,9 +104,9 @@ consider:
 
 ## Developing for the validator
 
-When proposing a feature or bug fix, you must decide what branch you will target:
+When proposing a feature or bug fix, you must decide which branch you will target:
 `main` or `dev`.
-In most cases, you will want `main`, but read below to understand the purposes of
+In most cases you will want `main`, but read below to understand the purposes of
 the two branches.
 
 ### Branching policy
@@ -121,7 +121,7 @@ specification.
 The purpose of this branch is to verify that proposed rules can be validated and
 provide users with preview access to upcoming changes to the validator, increasing the chances
 of catching issues with the specification or the validator, prior to release.
-Changes to the `dev` branch may be backed out at any time.
+Changes to the `dev` branch may be reverted at any time.
 
 ### How to prepare a pull request for your target branch
 
@@ -138,13 +138,13 @@ from the current state of the `main` branch on the `upstream` remote.
 Instead of `short-desc`, use a few words to make the content of your branch
 easily identifiable.
 
-Once ready
+Once you have changes committed and ready for review you can run:
 
 ```console
 git push -u origin feat/short-desc
 ```
 
-GitHub will give you a link, such as
+GitHub will then give you a link such as:
 <https://github.com/bids-standard/bids-validator/compare/master...username:bids-validator:feat/short-desc?expand=1>.
 Follow that link to create a pull request.
 

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -13,6 +13,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  debug_info:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git status
+      - run: git describe
+      - run: env
+      - name: Dump github context
+        run: echo $GITHUB_CONTEXT | jq .
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Disable example that requires network access
         run: touch tests/data/bids-examples/xeeg_hed_score/.SKIP_VALIDATION
         if: ${{ ! matrix.allow-net }}
+      - name: Disable unreleased examples
+        run: touch tests/data/bids-examples/dwi_deriv/.SKIP_VALIDATION
+        if: github.ref_name != 'dev'
       - run: deno test --node-modules-dir=auto $PERMS --coverage=cov/ src/
       - name: Collect coverage
         run: deno coverage cov/ --lcov --output=coverage.lcov

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ ! matrix.allow-net }}
       - name: Disable unreleased examples
         run: touch tests/data/bids-examples/dwi_deriv/.SKIP_VALIDATION
-        if: github.ref_name != 'dev'
+        if: github.ref_name != 'dev' && github.base_ref != 'dev'
       - run: deno test --node-modules-dir=auto $PERMS --coverage=cov/ src/
       - name: Collect coverage
         run: deno coverage cov/ --lcov --output=coverage.lcov

--- a/deno.json
+++ b/deno.json
@@ -24,7 +24,7 @@
   },
   "imports": {
     "@ajv": "npm:ajv@8.17.1",
-    "@bids/schema": "jsr:@bids/schema@0.11.4-dev.10+436d7cde",
+    "@bids/schema": "jsr:@bids/schema@0.11.3+2",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
     "@hed/validator": "npm:hed-validator@3.15.5",


### PR DESCRIPTION
Replacing the short-lived `stable`/`main` duo with `main`/`dev`. Docs to hopefully make things clear.