### PR TITLE
chore(ci): Publish to JSR on tag

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Check tag matches ${{ github.ref_name }}
-        run: jq -e ".version==\"${TAG#v}\"" deno.json
+        run: jq -e ".version[:1] != \"v\" and .version==\"$TAG\"" deno.json
         env:
           TAG: ${{ github.ref_name }}
       - uses: denoland/setup-deno@v2

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -95,6 +95,25 @@ jobs:
           deno-version: v2.x
       - run: deno publish --dry-run
 
+  publish:
+    runs-on: ubuntu-latest
+    needs: [test, publish-dry-run]
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check tag matches ${{ github.ref_name }}
+        run: jq -e ".version==\"${TAG#v}\"" deno.json
+        env:
+          TAG: ${{ github.ref_name }}
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - run: deno publish
+
   deploy:
     needs: [build]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pretty simple. Just includes a `jq` sanity check to make sure the tag matches the `deno.json` field.

We could build on this in the future to push regular dev builds.