### PR TITLE
chore: bump schema, refresh lock

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
   },
   "imports": {
     "@ajv": "npm:ajv@8.17.1",
-    "@bids/schema": "jsr:@bids/schema@0.11.3+2",
+    "@bids/schema": "jsr:@bids/schema@^0.11.3+2",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
     "@hed/validator": "npm:hed-validator@3.15.5",

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@bids/schema@0.11.3+2": "0.11.3+1",
+    "jsr:@bids/schema@~0.11.3+2": "0.11.3+2",
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
@@ -9,13 +9,9 @@
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@libs/typing@3": "3.1.0",
     "jsr:@libs/xml@6.0.1": "6.0.1",
-    "jsr:@luca/esbuild-deno-loader@0.10.3": "0.10.3",
     "jsr:@luca/esbuild-deno-loader@0.11.0": "0.11.0",
     "jsr:@std/assert@1.0.7": "1.0.7",
-    "jsr:@std/assert@~0.213.1": "0.213.1",
-    "jsr:@std/bytes@^1.0.2": "1.0.2",
-    "jsr:@std/bytes@^1.0.2-rc.3": "1.0.2",
-    "jsr:@std/encoding@0.213": "0.213.1",
+    "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/encoding@^1.0.5": "1.0.5",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fmt@^1.0.2": "1.0.3",
@@ -25,11 +21,9 @@
     "jsr:@std/internal@^1.0.5": "1.0.5",
     "jsr:@std/io@0.225": "0.225.0",
     "jsr:@std/io@0.225.0": "0.225.0",
-    "jsr:@std/jsonc@0.213": "0.213.1",
     "jsr:@std/log@0.224.9": "0.224.9",
-    "jsr:@std/path@0.213": "0.213.1",
     "jsr:@std/path@1.0.8": "1.0.8",
-    "jsr:@std/path@^1.0.6": "1.0.6",
+    "jsr:@std/path@^1.0.6": "1.0.8",
     "jsr:@std/path@^1.0.7": "1.0.8",
     "jsr:@std/text@~1.0.7": "1.0.8",
     "jsr:@std/yaml@^1.0.4": "1.0.5",
@@ -39,8 +33,8 @@
     "npm:ignore@6.0.2": "6.0.2"
   },
   "jsr": {
-    "@bids/schema@0.11.3+1": {
-      "integrity": "331d9975fe35175e5fc4990e97abf6459f564bc630309ae80ceee98211123cfb"
+    "@bids/schema@0.11.3+2": {
+      "integrity": "78b91d9c04b3c2c97aae163b057b3f9e47e4b7cdb2f2d9825c472b8e3086ad45"
     },
     "@cliffy/flags@1.0.0-rc.7": {
       "integrity": "318d9be98f6a6417b108e03dec427dea96cdd41a15beb21d2554ae6da450a781",
@@ -76,24 +70,13 @@
         "jsr:@libs/typing"
       ]
     },
-    "@luca/esbuild-deno-loader@0.10.3": {
-      "integrity": "32fc93f7e7f78060234fd5929a740668aab1c742b808c6048b57f9aaea514921",
-      "dependencies": [
-        "jsr:@std/encoding@0.213",
-        "jsr:@std/jsonc",
-        "jsr:@std/path@0.213"
-      ]
-    },
     "@luca/esbuild-deno-loader@0.11.0": {
       "integrity": "c05a989aa7c4ee6992a27be5f15cfc5be12834cab7ff84cabb47313737c51a2c",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.2",
-        "jsr:@std/encoding@^1.0.5",
+        "jsr:@std/bytes",
+        "jsr:@std/encoding",
         "jsr:@std/path@^1.0.6"
       ]
-    },
-    "@std/assert@0.213.1": {
-      "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
     },
     "@std/assert@1.0.7": {
       "integrity": "64ce9fac879e0b9f3042a89b3c3f8ccfc9c984391af19e2087513a79d73e28c3",
@@ -101,11 +84,8 @@
         "jsr:@std/internal"
       ]
     },
-    "@std/bytes@1.0.2": {
-      "integrity": "fbdee322bbd8c599a6af186a1603b3355e59a5fb1baa139f8f4c3c9a1b3e3d57"
-    },
-    "@std/encoding@0.213.1": {
-      "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
+    "@std/bytes@1.0.4": {
+      "integrity": "11a0debe522707c95c7b7ef89b478c13fb1583a7cfb9a85674cd2cc2e3a28abc"
     },
     "@std/encoding@1.0.5": {
       "integrity": "ecf363d4fc25bd85bd915ff6733a7e79b67e0e7806334af15f4645c569fefc04"
@@ -125,13 +105,7 @@
     "@std/io@0.225.0": {
       "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.2"
-      ]
-    },
-    "@std/jsonc@0.213.1": {
-      "integrity": "5578f21aa583b7eb7317eed077ffcde47b294f1056bdbb9aacec407758637bfe",
-      "dependencies": [
-        "jsr:@std/assert@~0.213.1"
+        "jsr:@std/bytes"
       ]
     },
     "@std/log@0.224.9": {
@@ -141,15 +115,6 @@
         "jsr:@std/fs@^1.0.4",
         "jsr:@std/io@0.225"
       ]
-    },
-    "@std/path@0.213.1": {
-      "integrity": "f187bf278a172752e02fcbacf6bd78a335ed320d080a7ed3a5a59c3e88abc673",
-      "dependencies": [
-        "jsr:@std/assert@~0.213.1"
-      ]
-    },
-    "@std/path@1.0.6": {
-      "integrity": "ab2c55f902b380cf28e0eec501b4906e4c1960d13f00e11cfbcd21de15f18fed"
     },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
@@ -205,8 +170,8 @@
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "fast-uri@3.0.1": {
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw=="
+    "fast-uri@3.0.3": {
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw=="
     },
     "fflate@0.8.2": {
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
@@ -283,8 +248,8 @@
     "tr46@0.0.3": {
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "unicode-name@1.0.2": {
-      "integrity": "sha512-PETEgU8TKsHoGZXP/3eWRU/4xnXJKwAIm+H7b0s/6CEP6o+YK4tWbwBXPLKe0U5+njWEAo2snT5+Mvoau6BI8A=="
+    "unicode-name@1.0.4": {
+      "integrity": "sha512-Y8KWGWHyZo5MVHsdjSFIshZesmQbLkh0l7RAv4uFNgVMjBIaCWVZAzch5b9jKaMHDnhroebDoM79/lLpzBLKvQ=="
     },
     "util@0.10.4": {
       "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
@@ -402,7 +367,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@bids/schema@0.11.3+2",
+      "jsr:@bids/schema@~0.11.3+2",
       "jsr:@effigies/cliffy-command@1.0.0-dev.8",
       "jsr:@effigies/cliffy-table@1.0.0-dev.5",
       "jsr:@libs/xml@6.0.1",


### PR DESCRIPTION
Using ^ seems to be necessary to get Deno to use post-releases reliably.