### PR TITLE
rf(filetree): Uniformize bidsignore reading between web, CLI and test functions

### DIFF
--- a/src/files/browser.ts
+++ b/src/files/browser.ts
@@ -52,7 +52,7 @@ export class BIDSFileBrowser implements BIDSFile {
 export async function fileListToTree(files: File[]): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
   const root = new FileTree('/', '/', undefined)
-  const tree = filesToTree(files.map((f) => new BIDSFileBrowser(f, ignore, root)))
+  const tree = filesToTree(files.map((f) => new BIDSFileBrowser(f, ignore, root)), ignore)
   const bidsignore = tree.get('.bidsignore')
   if (bidsignore) {
     try {

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -151,17 +151,14 @@ async function _readFileTree(
  */
 export async function readFileTree(rootPath: string): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
-  try {
-    const ignoreFile = new BIDSFileDeno(
-      rootPath,
-      '.bidsignore',
-      ignore,
-    )
-    ignore.add(await readBidsIgnore(ignoreFile))
-  } catch (err) {
-    if (err && typeof err === 'object' && !('code' in err && err.code === 'ENOENT')) {
-      logger.error(`Failed to read '.bidsignore' file with the following error:\n${err}`)
+  const tree = await _readFileTree(rootPath, '/', ignore)
+  const bidsignore = tree.get('.bidsignore')
+  if (bidsignore) {
+    try {
+      ignore.add(await readBidsIgnore(bidsignore as BIDSFile))
+    } catch (err) {
+      console.log(`Failed to read '.bidsignore' file with the following error:\n${err}`)
     }
   }
-  return _readFileTree(rootPath, '/', ignore)
+  return tree
 }

--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from '@std/assert'
 import type { FileIgnoreRules } from './ignore.ts'
-import type { FileTree } from '../types/filetree.ts'
+import type { BIDSFile, FileTree } from '../types/filetree.ts'
 import { filesToTree, pathsToTree } from './filetree.ts'
 
 Deno.test('FileTree generation', async (t) => {
@@ -49,5 +49,20 @@ Deno.test('FileTree generation', async (t) => {
     assert(tree.contains(['sub-01']))
     assert(tree.contains(['sub-01', 'anat']))
     assert(tree.contains(['sub-01', 'anat', 'sub-01_T1w.nii.gz']))
+  })
+  await t.step('converts a list with ignores', async () => {
+    const tree = pathsToTree(
+      ['/dataset_description.json', '/README.md', '/.bidsignore', '/bad_file'],
+      ['bad_file'],
+    )
+    assertEquals(tree.directories, [])
+    assertEquals(tree.files.map((f) => f.name), [
+      'dataset_description.json',
+      'README.md',
+      '.bidsignore',
+      'bad_file',
+    ])
+    const bad_file = tree.get('bad_file') as BIDSFile
+    assert(bad_file.ignored)
   })
 })

--- a/src/files/filetree.ts
+++ b/src/files/filetree.ts
@@ -1,10 +1,10 @@
 import { parse, SEPARATOR_PATTERN } from '@std/path'
 import * as posix from '@std/path/posix'
 import { type BIDSFile, FileTree } from '../types/filetree.ts'
+import { FileIgnoreRules } from './ignore.ts'
 
 const nullFile = {
   size: 0,
-  ignored: false,
   stream: new ReadableStream(),
   text: () => Promise.resolve(''),
   readBytes: async (size: number, offset?: number) => new Uint8Array(),
@@ -12,16 +12,18 @@ const nullFile = {
   viewed: false,
 }
 
-export function pathToFile(path: string): BIDSFile {
+export function pathToFile(path: string, ignored: boolean = false): BIDSFile {
   const name = path.split('/').pop() as string
-  return { name, path, ...nullFile }
+  return { name, path, ignored, ...nullFile }
 }
 
-export function pathsToTree(paths: string[]): FileTree {
-  return filesToTree(paths.map(pathToFile))
+export function pathsToTree(paths: string[], ignore?: string[]): FileTree {
+  const ignoreRules = new FileIgnoreRules(ignore ?? [])
+  return filesToTree(paths.map((path) => pathToFile(path, ignoreRules.test(path))))
 }
 
-export function filesToTree(fileList: BIDSFile[]): FileTree {
+export function filesToTree(fileList: BIDSFile[], ignore?: FileIgnoreRules): FileTree {
+  ignore = ignore ?? new FileIgnoreRules([])
   const tree: FileTree = new FileTree('/', '/')
   for (const file of fileList) {
     const parts = parse(file.path)
@@ -37,7 +39,7 @@ export function filesToTree(fileList: BIDSFile[]): FileTree {
         current = exists
         continue
       }
-      const newTree = new FileTree(posix.join(current.path, level), level, current)
+      const newTree = new FileTree(posix.join(current.path, level), level, current, ignore)
       current.directories.push(newTree)
       current = newTree
     }


### PR DESCRIPTION
Currently, the Deno CLI reads the bidsignore file and then loads the filetree. The premature load isn't necessary because `FileTree`s now can hold a reference to the `FileIgnoreRules` object.

The web UI loads the `FileTree` without passing them a reference to the `FileIgnoreRules` object, and then loads the bidsignore after the fact. So this has the possibility of missing ignores that https://github.com/bids-standard/legacy-validator/pull/2152 was intended to address.

Finally, the `pathsToTree` function doesn't allow any ignoring at all, which limits our ability to write tests.

This PR allows `filesToTree` to accept a `FileIgnoreRules` object and inject it in every `FileTree` it creates. Then we can make the web/CLI implementations work the same: build the tree, load the bidsignore. The `pathsToTree` function can accept a list of paths or patterns.

Follow-up to https://github.com/bids-standard/legacy-validator/pull/2152.