### PR TITLE
Fix bst call for compiling schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To modify the schema a clone of bids-standard/bids-specification will need to be
 
 After changes to the schema have been made to a local copy the dereferenced single json file used by the validator will need to be built. The `bidsschematools` python package does this. It can be installed from pypi via pip or a local installation can be made. It lives in the specification repository here https://github.com/bids-standard/bids-specification/tree/master/tools/schemacode
 
-The command to compile a dereferenced schema is `bst -v export --output src/schema.json` (this assumes you are in the root of the bids-specification repo). Once compiled it can be passed to the validator via the `-s` flag, `./bids-validator-deno -s <path to schema> <path to dataset>`
+The command to compile a dereferenced schema is `bst -v export --schema src/schema --output src/schema.json` (this assumes you are in the root of the bids-specification repo). Once compiled it can be passed to the validator via the `-s` flag, `./bids-validator-deno -s <path to schema> <path to dataset>`
 
 
 ## Documentation


### PR DESCRIPTION
Without providing a schema path, bst defaults to another installed schema instead of my modifies one:

```
2024-11-22 15:40:41,436 [    INFO] No schema path specified, defaulting to the bundled schema, `/home/tstoeter/.local/lib/python3.11/site-packages/bidsschematools/data/schema`.
```

Making the schema path explicit fixes this.