### PR TITLE
chore: Bump @bids/schema v1.0.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
   },
   "imports": {
     "@ajv": "npm:ajv@8.17.1",
-    "@bids/schema": "jsr:@bids/schema@0.11.3+2",
+    "@bids/schema": "jsr:@bids/schema@1.0.0",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
     "@hed/validator": "npm:hed-validator@3.15.5",


### PR DESCRIPTION
The schema is effectively stable, in that it's a pain to change it significantly. We're recognizing that by releasing the latest BIDS 1.10.0 schema patch as schema-1.0.0. I will make a corresponding bump to have `dev` track schema-1.1.0-dev.