### PR TITLE
Add -W (--allow-write) to deno build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ deno run -ERWN jsr:@bids/validator
 ```
 
 Deno by default sandboxes applications like a web browser.
-`-E`, `-R` and `-N` allow the validator to read environment variables,
-local files, and network locations.
+`-E`, `-R`, '-W', and `-N` allow the validator to read environment variables,
+read/write local files, and read network locations.
 
 ### Configuration file
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The BIDS Validator can be run with the [Deno][] runtime
 (see [Deno - Installation][] for detailed installation instructions):
 
 ```shell
-deno run -ERN jsr:@bids/validator
+deno run -ERWN jsr:@bids/validator
 ```
 
 Deno by default sandboxes applications like a web browser.

--- a/docs/user_guide/command-line.md
+++ b/docs/user_guide/command-line.md
@@ -10,19 +10,19 @@ In general, there is no need to install Deno applications.
 `deno run` allows running from the Javascript Repository:
 
 ```sh
-deno run -ERN jsr:@bids/validator <dataset>
+deno run -ERWN jsr:@bids/validator <dataset>
 ```
 
 However, you can also install a lightweight script (into `$HOME/.deno/bin`):
 
 ```sh
-deno install -ERN -g -n bids-validator jsr:@bids/validator
+deno install -ERWN -g -n bids-validator jsr:@bids/validator
 ```
 
 Or compile a bundled binary:
 
 ```sh
-deno compile -ERN -o bids-validator jsr:@bids/validator
+deno compile -ERWN -o bids-validator jsr:@bids/validator
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ The BIDS Validator takes a single dataset as input:
 :sync: run
 
 ```sh
-deno run -ERN jsr:@bids/validator <dataset>
+deno run -ERWN jsr:@bids/validator <dataset>
 ```
 
 :::


### PR DESCRIPTION
Without that run which asks to save results into external file would fail with

	error: Uncaught (in promise) PermissionDenied: Requires write access to "derivatives/bids-validator/deno-bids-validator.txt", specify the required permissions during compilation using `deno compile --allow-write`
		at writeFileSync (ext:deno_fs/30_fs.js:899:3)
		at Object.writeTextFileSync (ext:deno_fs/30_fs.js:962:10)
		at main (https://jsr.io/@bids/validator/2.0.1/src/main.ts:38:12)
		at eventLoopTick (ext:core/01_core.js:175:7)
		at async https://jsr.io/@bids/validator/2.0.1/src/bids-validator.ts:2:16

- There is also `--allow-run` which I do not know if should be enabled or not -- e.g. do you run HED validator as external tool, or anything else?

- Is it possible to identify such needs at compile time?