### PR TITLE
Updated the hed validation to only load schemas once

### DIFF
--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -39,6 +39,9 @@ export class BIDSContextDataset implements Dataset {
   schema: Schema
   pseudofileExtensions: Set<string>
 
+  // Opaque object for HED validator
+  hedSchemas: object | undefined | null = undefined
+
   constructor(
     args: Partial<BIDSContextDataset>,
   ) {

--- a/src/validators/hed.ts
+++ b/src/validators/hed.ts
@@ -22,25 +22,23 @@ function sidecarValueHasHed(sidecarValue: unknown) {
   )
 }
 
-let hedSchemas: object | undefined | null = undefined
-
-async function setHedSchemas(datasetDescriptionJson = {}) {
-  if (hedSchemas !== undefined) {
+async function setHedSchemas(dataset: BIDSContextDataset) {
+  if (dataset.hedSchemas !== undefined) {
     return [] as HedIssue[]
   }
   const datasetDescriptionData = new hedValidator.bids.BidsJsonFile(
     '/dataset_description.json',
-    datasetDescriptionJson,
+    dataset.dataset_description,
     null,
   )
   try {
-    hedSchemas = await hedValidator.bids.buildBidsSchemas(
+    dataset.hedSchemas = await hedValidator.bids.buildBidsSchemas(
       datasetDescriptionData,
       null,
     )
     return [] as HedIssue[]
   } catch (issueError) {
-    hedSchemas = null
+    dataset.hedSchemas = null
     return hedValidator.bids.BidsHedIssue.fromHedIssues(
       issueError,
       datasetDescriptionData.file,
@@ -66,18 +64,16 @@ export async function hedValidate(
       if (!('HED' in context.columns) && !sidecarHasHed(context.sidecar)) {
         return
       }
-      hedValidationIssues = await setHedSchemas(context.dataset.dataset_description)
+      hedValidationIssues = await setHedSchemas(context.dataset)
 
       file = await buildHedTsvFile(context)
     } else if (context.extension === '.json' && sidecarHasHed(context.json)) {
-      hedValidationIssues = hedValidationIssues = await setHedSchemas(
-        context.dataset.dataset_description,
-      )
+      hedValidationIssues = hedValidationIssues = await setHedSchemas(context.dataset)
       file = buildHedSidecarFile(context)
     }
 
     if (file) {
-      hedValidationIssues.push(...file.validate(hedSchemas))
+      hedValidationIssues.push(...file.validate(context.dataset.hedSchemas))
     }
   } catch (error) {
     context.dataset.issues.add({

--- a/src/validators/hed.ts
+++ b/src/validators/hed.ts
@@ -25,6 +25,9 @@ function sidecarValueHasHed(sidecarValue: unknown) {
 let hedSchemas: object | undefined | null = undefined
 
 async function setHedSchemas(datasetDescriptionJson = {}) {
+  if (hedSchemas !== undefined) {
+    return [] as HedIssue[]
+  }
   const datasetDescriptionData = new hedValidator.bids.BidsJsonFile(
     '/dataset_description.json',
     datasetDescriptionJson,
@@ -59,14 +62,14 @@ export async function hedValidate(
   let hedValidationIssues = [] as HedIssue[]
 
   try {
-    if (context.extension == '.tsv' && context.columns) {
+    if (context.extension === '.tsv' && context.columns) {
       if (!('HED' in context.columns) && !sidecarHasHed(context.sidecar)) {
         return
       }
       hedValidationIssues = await setHedSchemas(context.dataset.dataset_description)
 
       file = await buildHedTsvFile(context)
-    } else if (context.extension == '.json' && sidecarHasHed(context.json)) {
+    } else if (context.extension === '.json' && sidecarHasHed(context.json)) {
       hedValidationIssues = hedValidationIssues = await setHedSchemas(
         context.dataset.dataset_description,
       )


### PR DESCRIPTION
@rwblair  In looking at `hed.js` it looks as though the `hedSchemas` object is being reloaded for every file being validated. Since the HED schema version specification is the same for an entire BIDS dataset, it need only be loaded once.

@happy5214 (FYI)