### PR TITLE
fix: Load subjects

### DIFF
--- a/changelog.d/20250214_094554_markiewicz_load_subjects.md
+++ b/changelog.d/20250214_094554_markiewicz_load_subjects.md
@@ -1,0 +1,51 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+
+### Fixed
+
+- Subject detection in `participants.tsv` and `phenotype/` directories
+  has been restored, enabling checks that were deactivated by the missing
+  data. ([#162])
+
+[#162]: https://github.com/bids-standard/bids-validator/pull/162
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -63,11 +63,8 @@ export class BIDSContextDataset implements Dataset {
           ?.filter((ext) => ext.endsWith('/'))
         : [],
     )
-    this.subjects = args.subjects || {
-      sub_dirs: this.tree.directories.map((dir) => dir.name).filter((dir) =>
-        dir.startsWith('sub-')
-      ),
-    }
+    // @ts-ignore
+    this.subjects = args.subjects || null
   }
 
   get dataset_description(): Record<string, unknown> {


### PR DESCRIPTION
Type checker doesn't like it, but this fixes the failure to load from TSV files for now. We don't want to synchronously load TSV files during object construction, but nor do we really want to treat subjects as maybe missing.

The real fix I think will be to only call the function once, so we can get rid of the `null` check.