### PR TITLE
fix: Prevent AJV logs from contaminating output

### DIFF
--- a/src/validators/json.ts
+++ b/src/validators/json.ts
@@ -3,7 +3,7 @@ import type { Schema } from '../types/schema.ts'
 import { memoize } from '../utils/memoize.ts'
 import { logger } from '../utils/logger.ts'
 
-const metadataValidator = new Ajv({ strictSchema: false })
+const metadataValidator = new Ajv({ strictSchema: false, logger: false })
 
 // Bind the method to the instance before memoizing to avoid losing the context
 export const compile = memoize(metadataValidator.compile.bind(metadataValidator))


### PR DESCRIPTION
Some datasets on OpenNeuro are having JSON output contaminated by this output from AJV's internal logging:

```
strict mode: missing type "array" for keyword "maxItems" at "#/properties/ScreenResolution/anyOf/0/items" (strictTypes)
strict mode: missing type "array" for keyword "minItems" at "#/properties/ScreenResolution/anyOf/0/items" (strictTypes)
strict mode: missing type "array" for keyword "maxItems" at "#/properties/ScreenSize/anyOf/0/items" (strictTypes)
strict mode: missing type "array" for keyword "minItems" at "#/properties/ScreenSize/anyOf/0/items" (strictTypes)
```

Examples include ds005810 and ds005811.