### PR TITLE
fix: Cast ArrayBufferLikes to ArrayBuffer in read-only contexts

### DIFF
--- a/src/files/nifti.ts
+++ b/src/files/nifti.ts
@@ -34,15 +34,15 @@ async function extract(buffer: Uint8Array, nbytes: number): Promise<Uint8Array> 
 export async function loadHeader(file: BIDSFile): Promise<NiftiHeader> {
   try {
     const buf = await file.readBytes(1024)
-    const data = isCompressed(buf.buffer) ? await extract(buf, 540) : buf.slice(0, 540)
+    const data = isCompressed(buf.buffer as ArrayBuffer) ? await extract(buf, 540) : buf.slice(0, 540)
     let header
-    if (isNIFTI1(data.buffer)) {
+    if (isNIFTI1(data.buffer as ArrayBuffer)) {
       header = new NIFTI1()
       // Truncate to 348 bytes to avoid attempting to parse extensions
-      header.readHeader(data.buffer.slice(0, 348))
-    } else if (isNIFTI2(data.buffer)) {
+      header.readHeader(data.buffer.slice(0, 348) as ArrayBuffer)
+    } else if (isNIFTI2(data.buffer as ArrayBuffer)) {
       header = new NIFTI2()
-      header.readHeader(data.buffer)
+      header.readHeader(data.buffer as ArrayBuffer)
     }
     if (!header) {
       throw { key: 'NIFTI_HEADER_UNREADABLE' }

--- a/src/files/tiff.ts
+++ b/src/files/tiff.ts
@@ -27,7 +27,7 @@ function getImageDescription(
     if (dataview.getUint16(IFDoffset + 2 + i * IFDsize, littleEndian) === 0x010e) {
       const nbytes = dataview.getUint32(IFDoffset + 2 + i * IFDsize + 4, littleEndian)
       const offset = dataview.getUint32(IFDoffset + 2 + i * IFDsize + 8, littleEndian)
-      return new TextDecoder().decode(dataview.buffer.slice(offset, offset + nbytes))
+      return new TextDecoder().decode(dataview.buffer.slice(offset, offset + nbytes) as ArrayBuffer)
     }
   }
 }


### PR DESCRIPTION
Errors seen in #166 and confirmed in `main`: https://github.com/bids-standard/bids-validator/actions/runs/13376538054/job/37571236055

In all of these contexts, the buffers are read-only, so it is safe to claim additional, unused properties.