### PR TITLE
chore: Bump @bids/schema v1.0.3 and other dependencies

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
   },
   "imports": {
     "@ajv": "npm:ajv@8.17.1",
-    "@bids/schema": "jsr:@bids/schema@1.0.1",
+    "@bids/schema": "jsr:@bids/schema@1.0.3",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
     "@hed/validator": "npm:hed-validator@3.15.5",

--- a/deno.json
+++ b/deno.json
@@ -33,7 +33,7 @@
     "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
     "@hed/validator": "npm:hed-validator@3.15.5",
     "@ignore": "npm:ignore@7.0.3",
-    "@libs/xml": "jsr:@libs/xml@6.0.1",
+    "@libs/xml": "jsr:@libs/xml@6.0.4",
     "@mango/nifti": "npm:@bids/nifti-reader-js@0.6.9",
     "@std/assert": "jsr:@std/assert@1.0.7",
     "@std/fmt": "jsr:@std/fmt@1.0.5",

--- a/deno.json
+++ b/deno.json
@@ -36,13 +36,13 @@
     "@libs/xml": "jsr:@libs/xml@6.0.1",
     "@mango/nifti": "npm:@bids/nifti-reader-js@0.6.9",
     "@std/assert": "jsr:@std/assert@1.0.7",
-    "@std/fmt": "jsr:@std/fmt@1.0.3",
-    "@std/fs": "jsr:@std/fs@1.0.5",
-    "@std/io": "jsr:@std/io@0.225.0",
-    "@std/log": "jsr:@std/log@0.224.9",
+    "@std/fmt": "jsr:@std/fmt@1.0.5",
+    "@std/fs": "jsr:@std/fs@1.0.13",
+    "@std/io": "jsr:@std/io@0.225.2",
+    "@std/log": "jsr:@std/log@0.224.14",
     "@std/path": "jsr:@std/path@1.0.8",
-    "@std/streams": "jsr:@std/streams@1.0.8",
-    "@std/yaml": "jsr:@std/yaml@^1.0.4"
+    "@std/streams": "jsr:@std/streams@1.0.9",
+    "@std/yaml": "jsr:@std/yaml@^1.0.5"
   },
   "tasks": {
     "test": "deno test -A src/"

--- a/deno.lock
+++ b/deno.lock
@@ -1,15 +1,14 @@
 {
   "version": "4",
   "specifiers": {
-    "jsr:@bids/schema@1.0.1": "1.0.1",
+    "jsr:@bids/schema@1.0.3": "1.0.3",
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
-    "jsr:@libs/typing@3": "3.1.0",
-    "jsr:@libs/xml@6.0.1": "6.0.1",
+    "jsr:@libs/xml@6.0.4": "6.0.4",
     "jsr:@luca/esbuild-deno-loader@0.10.3": "0.10.3",
     "jsr:@luca/esbuild-deno-loader@0.11.0": "0.11.0",
     "jsr:@std/assert@1.0.7": "1.0.7",
@@ -17,33 +16,38 @@
     "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/bytes@^1.0.2-rc.3": "1.0.2",
     "jsr:@std/bytes@^1.0.3": "1.0.4",
+    "jsr:@std/bytes@^1.0.5": "1.0.5",
     "jsr:@std/encoding@0.213": "0.213.1",
     "jsr:@std/encoding@^1.0.5": "1.0.5",
     "jsr:@std/fmt@1.0.3": "1.0.3",
+    "jsr:@std/fmt@1.0.5": "1.0.5",
     "jsr:@std/fmt@^1.0.2": "1.0.3",
-    "jsr:@std/fmt@~1.0.2": "1.0.3",
-    "jsr:@std/fs@1.0.5": "1.0.5",
-    "jsr:@std/fs@^1.0.4": "1.0.5",
+    "jsr:@std/fmt@^1.0.5": "1.0.5",
+    "jsr:@std/fmt@~1.0.2": "1.0.5",
+    "jsr:@std/fs@1.0.11": "1.0.11",
+    "jsr:@std/fs@1.0.13": "1.0.13",
+    "jsr:@std/fs@^1.0.11": "1.0.13",
     "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/io@0.225": "0.225.0",
-    "jsr:@std/io@0.225.0": "0.225.0",
+    "jsr:@std/io@0.225.2": "0.225.2",
+    "jsr:@std/io@~0.225.2": "0.225.2",
     "jsr:@std/jsonc@0.213": "0.213.1",
-    "jsr:@std/log@0.224.9": "0.224.9",
+    "jsr:@std/log@0.224.14": "0.224.14",
     "jsr:@std/path@0.213": "0.213.1",
     "jsr:@std/path@1.0.8": "1.0.8",
     "jsr:@std/path@^1.0.6": "1.0.6",
     "jsr:@std/path@^1.0.7": "1.0.8",
-    "jsr:@std/streams@1.0.8": "1.0.8",
+    "jsr:@std/path@^1.0.8": "1.0.8",
+    "jsr:@std/streams@1.0.9": "1.0.9",
     "jsr:@std/text@~1.0.7": "1.0.8",
-    "jsr:@std/yaml@^1.0.4": "1.0.5",
+    "jsr:@std/yaml@^1.0.5": "1.0.5",
     "npm:@bids/nifti-reader-js@0.6.9": "0.6.9",
     "npm:ajv@8.17.1": "8.17.1",
     "npm:hed-validator@3.15.5": "3.15.5",
     "npm:ignore@7.0.3": "7.0.3"
   },
   "jsr": {
-    "@bids/schema@1.0.1": {
-      "integrity": "f061e6bcc2eaff9867b5d126ca0b8a77f983201b95a267feb7a01fa69a89b878"
+    "@bids/schema@1.0.3": {
+      "integrity": "028addae5f47974dc9904b0186b6b0f961620e0faf67a7d350284d529b3bbc62"
     },
     "@cliffy/flags@1.0.0-rc.7": {
       "integrity": "318d9be98f6a6417b108e03dec427dea96cdd41a15beb21d2554ae6da450a781",
@@ -77,14 +81,8 @@
         "jsr:@std/fmt@~1.0.2"
       ]
     },
-    "@libs/typing@3.1.0": {
-      "integrity": "091b59f57a99f84c9fccf8f59534f77f177705ac25183b575c83fd7aa6dcfafe"
-    },
-    "@libs/xml@6.0.1": {
-      "integrity": "64af4f93464c77c3e1158fb97c3657779ca554b14f38616b96cde31e22d8a309",
-      "dependencies": [
-        "jsr:@libs/typing"
-      ]
+    "@libs/xml@6.0.4": {
+      "integrity": "c896f17016dbf5f2d62496e0bd6cd7db145c05987d0e45d4dd2c87785a60f528"
     },
     "@luca/esbuild-deno-loader@0.10.3": {
       "integrity": "32fc93f7e7f78060234fd5929a740668aab1c742b808c6048b57f9aaea514921",
@@ -117,6 +115,9 @@
     "@std/bytes@1.0.4": {
       "integrity": "11a0debe522707c95c7b7ef89b478c13fb1583a7cfb9a85674cd2cc2e3a28abc"
     },
+    "@std/bytes@1.0.5": {
+      "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
+    },
     "@std/encoding@0.213.1": {
       "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
     },
@@ -126,19 +127,28 @@
     "@std/fmt@1.0.3": {
       "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
     },
-    "@std/fs@1.0.5": {
-      "integrity": "41806ad6823d0b5f275f9849a2640d87e4ef67c51ee1b8fb02426f55e02fd44e",
+    "@std/fmt@1.0.5": {
+      "integrity": "0cfab43364bc36650d83c425cd6d99910fc20c4576631149f0f987eddede1a4d"
+    },
+    "@std/fs@1.0.11": {
+      "integrity": "ba674672693340c5ebdd018b4fe1af46cb08741f42b4c538154e97d217b55bdd",
       "dependencies": [
-        "jsr:@std/path@^1.0.7"
+        "jsr:@std/path@^1.0.8"
+      ]
+    },
+    "@std/fs@1.0.13": {
+      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605",
+      "dependencies": [
+        "jsr:@std/path@^1.0.8"
       ]
     },
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
     },
-    "@std/io@0.225.0": {
-      "integrity": "c1db7c5e5a231629b32d64b9a53139445b2ca640d828c26bf23e1c55f8c079b3",
+    "@std/io@0.225.2": {
+      "integrity": "3c740cd4ee4c082e6cfc86458f47e2ab7cb353dc6234d5e9b1f91a2de5f4d6c7",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.2"
+        "jsr:@std/bytes@^1.0.5"
       ]
     },
     "@std/jsonc@0.213.1": {
@@ -147,12 +157,12 @@
         "jsr:@std/assert@~0.213.1"
       ]
     },
-    "@std/log@0.224.9": {
-      "integrity": "419d04e4d93e6b1a0205ac3f94809621cfec3d328d09fec9ec59cafa3b3fcaee",
+    "@std/log@0.224.14": {
+      "integrity": "257f7adceee3b53bb2bc86c7242e7d1bc59729e57d4981c4a7e5b876c808f05e",
       "dependencies": [
-        "jsr:@std/fmt@^1.0.2",
-        "jsr:@std/fs@^1.0.4",
-        "jsr:@std/io@0.225"
+        "jsr:@std/fmt@^1.0.5",
+        "jsr:@std/fs@^1.0.11",
+        "jsr:@std/io@~0.225.2"
       ]
     },
     "@std/path@0.213.1": {
@@ -167,10 +177,10 @@
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
-    "@std/streams@1.0.8": {
-      "integrity": "b41332d93d2cf6a82fe4ac2153b930adf1a859392931e2a19d9fabfb6f154fb3",
+    "@std/streams@1.0.9": {
+      "integrity": "a9d26b1988cdd7aa7b1f4b51e1c36c1557f3f252880fa6cc5b9f37078b1a5035",
       "dependencies": [
-        "jsr:@std/bytes@^1.0.3"
+        "jsr:@std/bytes@^1.0.5"
       ]
     },
     "@std/text@1.0.8": {
@@ -421,18 +431,18 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@bids/schema@1.0.1",
+      "jsr:@bids/schema@1.0.3",
       "jsr:@effigies/cliffy-command@1.0.0-dev.8",
       "jsr:@effigies/cliffy-table@1.0.0-dev.5",
-      "jsr:@libs/xml@6.0.1",
+      "jsr:@libs/xml@6.0.4",
       "jsr:@std/assert@1.0.7",
-      "jsr:@std/fmt@1.0.3",
-      "jsr:@std/fs@1.0.5",
-      "jsr:@std/io@0.225.0",
-      "jsr:@std/log@0.224.9",
+      "jsr:@std/fmt@1.0.5",
+      "jsr:@std/fs@1.0.13",
+      "jsr:@std/io@0.225.2",
+      "jsr:@std/log@0.224.14",
       "jsr:@std/path@1.0.8",
-      "jsr:@std/streams@1.0.8",
-      "jsr:@std/yaml@^1.0.4",
+      "jsr:@std/streams@1.0.9",
+      "jsr:@std/yaml@^1.0.5",
       "npm:@bids/nifti-reader-js@0.6.9",
       "npm:ajv@8.17.1",
       "npm:hed-validator@3.15.5",


### PR DESCRIPTION
Holding off on `@std/assert`, since that breaks some equality checks.

Builds on #167 to ensure type checking passes.