### PR TITLE
chore: Bump @std/assert >= 1.0.8

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -35,7 +35,7 @@
     "@ignore": "npm:ignore@7.0.3",
     "@libs/xml": "jsr:@libs/xml@6.0.4",
     "@mango/nifti": "npm:@bids/nifti-reader-js@0.6.9",
-    "@std/assert": "jsr:@std/assert@1.0.7",
+    "@std/assert": "jsr:@std/assert@1.0.11",
     "@std/fmt": "jsr:@std/fmt@1.0.5",
     "@std/fs": "jsr:@std/fs@1.0.13",
     "@std/io": "jsr:@std/io@0.225.2",

--- a/deno.lock
+++ b/deno.lock
@@ -11,7 +11,7 @@
     "jsr:@libs/xml@6.0.4": "6.0.4",
     "jsr:@luca/esbuild-deno-loader@0.10.3": "0.10.3",
     "jsr:@luca/esbuild-deno-loader@0.11.0": "0.11.0",
-    "jsr:@std/assert@1.0.7": "1.0.7",
+    "jsr:@std/assert@1.0.11": "1.0.11",
     "jsr:@std/assert@~0.213.1": "0.213.1",
     "jsr:@std/bytes@^1.0.2": "1.0.4",
     "jsr:@std/bytes@^1.0.2-rc.3": "1.0.2",
@@ -103,8 +103,8 @@
     "@std/assert@0.213.1": {
       "integrity": "24c28178b30c8e0782c18e8e94ea72b16282207569cdd10ffb9d1d26f2edebfe"
     },
-    "@std/assert@1.0.7": {
-      "integrity": "64ce9fac879e0b9f3042a89b3c3f8ccfc9c984391af19e2087513a79d73e28c3",
+    "@std/assert@1.0.11": {
+      "integrity": "2461ef3c368fe88bc60e186e7744a93112f16fd110022e113a0849e94d1c83c1",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -435,7 +435,7 @@
       "jsr:@effigies/cliffy-command@1.0.0-dev.8",
       "jsr:@effigies/cliffy-table@1.0.0-dev.5",
       "jsr:@libs/xml@6.0.4",
-      "jsr:@std/assert@1.0.7",
+      "jsr:@std/assert@1.0.11",
       "jsr:@std/fmt@1.0.5",
       "jsr:@std/fs@1.0.13",
       "jsr:@std/io@0.225.2",

--- a/src/files/browser.test.ts
+++ b/src/files/browser.test.ts
@@ -2,6 +2,9 @@ import { FileIgnoreRules } from './ignore.ts'
 import { FileTree } from '../types/filetree.ts'
 import { assertEquals, assertObjectMatch } from '@std/assert'
 import { BIDSFileBrowser, fileListToTree } from './browser.ts'
+import { streamFromString } from '../tests/utils.ts'
+
+const nullstream = streamFromString('')
 
 class TestFile extends File {
   override webkitRelativePath: string
@@ -13,6 +16,7 @@ class TestFile extends File {
   ) {
     super(fileBits, fileName, options)
     this.webkitRelativePath = webkitRelativePath
+    this.stream = () => nullstream
   }
 }
 
@@ -79,7 +83,7 @@ Deno.test('Browser implementation of FileTree', async (t) => {
   })
 
   await t.step('reads .bidsignore during load', async () => {
-    const ignore = new FileIgnoreRules([])
+    const ignore = new FileIgnoreRules(['ignored_but_absent', 'ignored_and_present'])
     const files = [
       new TestFile(
         ['ignored_but_absent\n', 'ignored_and_present\n'],

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -46,6 +46,7 @@ export class FileTree {
   }
 
   get ignored(): boolean {
+    if (!this.parent) { return false }
     return this.#ignore.test(this.path)
   }
 


### PR DESCRIPTION
Follow-up to #168, addressing some changes in deep equality checking introduced in https://github.com/denoland/std/pull/6153. Now the values of `BIDSFile.stream` and `BIDSFile.ignore` are compared, while we were previously only checking structure. Adding a stream that is an identical object resolves the first, and the second requires ensuring `.ignore` does not crash on dataset roots and passing an expected `BIDSIgnore` to files in the expected tree.