### PR TITLE
fix: Correct Uint8Array / DataView usage for TypeScript 5.7

### DIFF
--- a/src/files/browser.ts
+++ b/src/files/browser.ts
@@ -41,7 +41,7 @@ export class BIDSFileBrowser implements BIDSFile {
     return this.#file.text()
   }
 
-  async readBytes(size: number, offset = 0): Promise<Uint8Array> {
+  async readBytes(size: number, offset = 0): Promise<Uint8Array<ArrayBuffer>> {
     return new Uint8Array(await this.#file.slice(offset, size).arrayBuffer())
   }
 }

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -78,7 +78,7 @@ export class BIDSFileDeno implements BIDSFile {
    * Reads up to size bytes, starting at offset.
    * If EOF is encountered, the resulting array may be smaller.
    */
-  async readBytes(size: number, offset = 0): Promise<Uint8Array> {
+  async readBytes(size: number, offset = 0): Promise<Uint8Array<ArrayBuffer>> {
     const handle = this.#openHandle()
     const buf = new Uint8Array(size)
     await handle.seek(offset, Deno.SeekMode.Start)

--- a/src/files/nifti.ts
+++ b/src/files/nifti.ts
@@ -3,7 +3,7 @@ import type { BIDSFile } from '../types/filetree.ts'
 import { logger } from '../utils/logger.ts'
 import type { NiftiHeader } from '@bids/schema/context'
 
-async function extract(buffer: Uint8Array, nbytes: number): Promise<Uint8Array> {
+async function extract(buffer: Uint8Array, nbytes: number): Promise<Uint8Array<ArrayBuffer>> {
   // The fflate decompression that is used in nifti-reader does not like
   // truncated data, so pretend that we have a stream and stop reading
   // when we have enough bytes.

--- a/src/files/tiff.ts
+++ b/src/files/tiff.ts
@@ -7,7 +7,7 @@ import * as XML from '@libs/xml'
 import type { BIDSFile } from '../types/filetree.ts'
 
 function getImageDescription(
-  dataview: DataView,
+  dataview: DataView<ArrayBuffer>,
   littleEndian: boolean,
   IFDsize: number,
 ): string | undefined {

--- a/src/schema/fixtures.test.ts
+++ b/src/schema/fixtures.test.ts
@@ -11,7 +11,7 @@ const subjectJson = JSON.stringify({ subOverwrite: 'subject', subValue: 'subject
 const rootJson = JSON.stringify({ rootOverwrite: 'root', rootValue: 'root' })
 
 function readBytes(json: string) {
-  return (size: number) => Promise.resolve(new TextEncoder().encode(json))
+  return (size: number) => Promise.resolve(new TextEncoder().encode(json) as Uint8Array<ArrayBuffer>)
 }
 
 export const rootFileTree = pathsToTree([
@@ -34,4 +34,5 @@ const anatFileTree = subjectFileTree.directories[0].directories[0] as FileTree
 
 export const dataFile = anatFileTree.get('sub-01_ses-01_T1w.nii.gz') as BIDSFile
 const anatJSONFile = anatFileTree.get('sub-01_ses-01_T1w.json') as BIDSFile
-anatJSONFile.readBytes = (size: number) => Promise.resolve(new TextEncoder().encode(anatJson))
+anatJSONFile.readBytes = (size: number) =>
+  Promise.resolve(new TextEncoder().encode(anatJson) as Uint8Array<ArrayBuffer>)

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -14,7 +14,7 @@ export interface BIDSFile {
   // Resolve stream to decoded utf-8 text
   text: () => Promise<string>
   // Read a range of bytes
-  readBytes: (size: number, offset?: number) => Promise<Uint8Array>
+  readBytes: (size: number, offset?: number) => Promise<Uint8Array<ArrayBuffer>>
   // Access the parent directory
   parent: FileTree
   // File has been viewed


### PR DESCRIPTION
Deno 2.2 via TypeScript 5.7 made typed arrays generic. Specifying the generic for Uint8Array and DataView resolves failures seen in #166.

@effigies I think this is the better alternative to #167.