### PR TITLE
fix: Run all test files with `deno task test`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -45,7 +45,7 @@
     "@std/yaml": "jsr:@std/yaml@^1.0.4"
   },
   "tasks": {
-    "test": "deno test -A src/tests/"
+    "test": "deno test -A src/"
   },
   "fmt": {
     "lineWidth": 99,


### PR DESCRIPTION
While debugging #170 I realized I wasn't seeing all errors because the test runner was pointed at just the tests directory.