### PR TITLE
Provide tool to build and distribute deno-compiled binary on PyPi

### DIFF
--- a/.github/workflows/pypi-whl.yml
+++ b/.github/workflows/pypi-whl.yml
@@ -1,0 +1,73 @@
+name: PyPI Whl Publish
+
+on:
+  push:
+    branches: [main, dev]
+    tags: ['*']
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+    working-directory: tools/pypi-whl
+
+jobs:
+  build_wheels:
+    name: Build whl on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        # windows-latest is an Intel runner
+        # macos-13 is an Intel runner, macos-latest is an Apple Silicon runner
+        # ubuntu-latest is an Intel runner, ubuntu-24.04-arm is an arm runner
+        os:
+          - windows-latest
+          - macos-13
+          - macos-latest
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Install build and twine
+        run: python -m pip install build twine
+      - name: Compile deno binaries
+        run: deno compile -ERNW --allow-run -o dist/bids-validator ../../src/bids-validator.ts
+      - name: Print out the content of the dist folder after building validator binary
+        run: ls -l dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bids-validator-${{ matrix.os }}
+          path: |
+            tools/pypi-whl/dist/bids-validator
+            tools/pypi-whl/dist/bids-validator.*
+      - name: Build wheel
+        run: python -m build --wheel
+      - name: Print out the content of the dist folder after building the wheel
+        run: ls -l dist/
+      - name: Validate the built wheel through installation and running the validator
+        run: ./validate_wheel.sh
+      - name: Check if distribution's description will render correctly on PyPI
+        run: twine check dist/*.whl
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}
+          path: tools/pypi-whl/dist/*.whl
+      - name: Publish wheels if corresponds to a version tag
+        if: github.ref_type == 'tag'
+        run: ./publish.sh
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+          TAG: ${{ github.ref_name }}

--- a/tools/pypi-whl/README.md
+++ b/tools/pypi-whl/README.md
@@ -1,0 +1,33 @@
+# bids-validator-deno
+
+**bids-validator-deno** is a Python installer (distributed as wheels on [PyPI](https://pypi.org)) 
+for the self-contained binary of 
+[bids-validator](https://github.com/bids-standard/bids-validator), 
+compiled with [`deno compile`](https://docs.deno.com/runtime/reference/cli/compile).
+-----
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [License](#license)
+
+## Installation
+
+```console
+pip install bids-validator-deno
+```
+
+## Usage
+Once installed, the `bids-validator` binary can be invoked from the command line.
+For usage instructions, run:
+
+```console
+bids-validator --help
+```
+
+## License
+
+`bids-validator-deno` is distributed under the terms of the same license as 
+[bids-validator](https://github.com/bids-standard/bids-validator?tab=readme-ov-file) itself, 
+which is [MIT](https://spdx.org/licenses/MIT.html) license.

--- a/tools/pypi-whl/pdm_build.py
+++ b/tools/pypi-whl/pdm_build.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import platform
+import sys
+from wheel.cli.tags import tags
+from pathlib import Path
+import shutil
+
+from pdm.backend.hooks import Context
+
+
+def get_platform_tag():
+    # Get machine architecture
+    arch = platform.machine()
+
+    # Validate architecture
+    if arch == "x86_64":
+        arch_tag = "x86_64"
+    elif arch in ("arm64", "aarch64"):
+        arch_tag = "arm64"
+    elif arch == "AMD64":
+        # seems to be the case on Windows
+        arch_tag = arch.lower()
+    else:
+        raise ValueError(f"Unsupported architecture: {arch}")
+
+    # Determine OS and construct the appropriate tag
+    if sys.platform.startswith("linux"):
+        if arch_tag == "arm64":
+            arch_tag = "aarch64"
+            platform_tag = f"manylinux_2_17_{arch_tag}.manylinux2014_{arch_tag}.musllinux_1_1_{arch_tag}"
+        else:
+            platform_tag = f"manylinux_2_17_{arch_tag}"
+    elif sys.platform == "darwin":
+        if arch_tag == "arm64":
+            platform_tag = f"macosx_11_0_{arch_tag}"
+        else:
+            platform_tag = f"macosx_10_16_{arch_tag}"
+    elif sys.platform.startswith("win"):
+        platform_tag = f"win_{arch_tag}"
+    else:
+        raise ValueError(f"Unsupported platform: {sys.platform}")
+
+    return platform_tag
+
+
+def pdm_build_finalize(context: Context, artifact: Path) -> None:
+    renamed = tags(
+        str(artifact),
+        python_tags="py3",
+        abi_tags="none",
+        platform_tags=get_platform_tag(),
+        remove=True,
+    )
+    print(f"INFO: {renamed}")
+
+    if context.build_dir.exists():
+        print(f"INFO: cleaning {context.build_dir}")
+        shutil.rmtree(context.build_dir)
+
+
+if __name__ == "__main__":
+    try:
+        tag = get_platform_tag()
+    except ValueError as e:
+        print(f"Error: {e}")
+    else:
+        print(f"The platform tag is: {tag}")

--- a/tools/pypi-whl/publish.sh
+++ b/tools/pypi-whl/publish.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# publish.sh
+
+# This script publishes the built wheel if the current tag corresponds to a version tag
+# It requires the tag to be passed as the `TAG` environment variable
+
+# Fail as soon as any command fails
+set -euo pipefail
+
+# Check if the tag is a release version tag
+set +e
+jq -e ".version[:1] != \"v\" and .version==\"$TAG\"" ../../deno.json
+ret=$?
+set -e
+if [ $ret -eq 0 ]; then
+    # Tag is a release version tag
+    twine upload --verbose dist/*.whl
+elif [ $ret -eq 1 ]; then
+    # Tag is not a release version tag
+    echo "Not releasing ($TAG is not a release version tag)"
+else
+    # jq command failed
+    echo "jq command failed with exit code $ret"
+    exit $ret
+fi

--- a/tools/pypi-whl/pyproject.toml
+++ b/tools/pypi-whl/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["pdm-backend", "wheel"]
+build-backend = "pdm.backend"
+
+[tool.pdm.build]
+is-purelib = false
+excludes = ["dist/*", "lib/*", ".gitignore"]
+
+[tool.pdm.build.wheel-data]
+scripts = ["dist/bids-validator", "dist/bids-validator.exe"]
+
+[tool.pdm.version]
+source = "scm"
+# tag_filter = "test/*"
+# tag_regex = '^test/(?:\D*)?(?P<version>([1-9][0-9]*!)?(0|[1-9][0-9]*)(\.(0|[1-9][0-9]*))*((a|b|c|rc)(0|[1-9][0-9]*))?(\.post(0|[1-9][0-9]*))?(\.dev(0|[1-9][0-9]*))?$)$'
+
+[project]
+name = "bids-validator-deno"
+dynamic = ["version"]
+description = "Python installer for the self-contained binary of bids-validator"
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+keywords = ["bids", "bids-validator"]
+authors = [{ name = "bids-standard developers" }]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+]
+dependencies = []
+
+[project.urls]
+Documentation = "https://github.com/bids-standard/bids-validator/tree/main/tools/pypi-whl"
+Issues = "https://github.com/bids-standard/bids-validator/issues"
+Source = "https://github.com/bids-standard/bids-validator/tree/main/tools/pypi-whl"
+

--- a/tools/pypi-whl/validate_wheel.sh
+++ b/tools/pypi-whl/validate_wheel.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# validate_wheel.sh
+
+# This script is used to validate the built wheel by installing it in a virtual
+# environment, running the installed packaged, and ascertaining that the deno-compiled
+# BIDS validator binary is correctly installed in the script or bin directory of the
+# virtual environment.
+
+# Fail as soon as any command fails
+set -euo pipefail
+
+python -m venv .venv
+
+if [[ "$RUNNER_OS" == "Windows" ]]; then
+    BIDS_VALIDATOR_BINARY_NAME="bids-validator.exe"
+    VENV_BIN_DIR=".venv/Scripts"
+else
+    BIDS_VALIDATOR_BINARY_NAME="bids-validator"
+    VENV_BIN_DIR=".venv/bin"
+fi
+
+# Activate the virtual environment
+source "$VENV_BIN_DIR"/activate
+
+# Install the built wheel
+pip install dist/*.whl
+
+# Smoke test with the `--version` option
+bids-validator --version
+
+# Display the script or bin directory of the virtual environment
+ls -lh "$VENV_BIN_DIR"
+
+# diff to confirm the binary is correctly installed
+diff "$VENV_BIN_DIR"/"$BIDS_VALIDATOR_BINARY_NAME" dist/"$BIDS_VALIDATOR_BINARY_NAME"
+# Deactivate environment
+deactivate


### PR DESCRIPTION
This PR closes #148. Please see commit messages for details.

**Note**:
1. The `--allow-run` option is used to compiled the BIDS validator from local source. Without this option, the compilation result would require the user to grant permission to run subprocesses. This option was not used/needed when compiling from the published jsr package from some reason. 
2. For publishing to work, please set up a github secret `PYPI_TOKEN` containing the PyPi token.


TODOs:
- [x] created https://pypi.org/project/bids-validator-deno/ by uploading 2.0.3 "manual" build done on my @yarikoptic linux laptop . Required "faking" this PR branch to be on 2.0.3 tag for proper tagging. Not sure if we need/want to upload more wheels similarly -- this workflow I think would not work unless we make it force similar nastiness somehow
- [x] invited @effigies @tsalo @candleindark to maintain this PyPI project
- [x] BTW -- I also applied for BIDS community organization on PyPI FWIW  
- [x] add PYPI_TOKEN
- [x] remove mentioning of testing pypi
- [x] validate publishing on test PyPi with the final setup. https://test.pypi.org/project/bids-validator-deno/2.0.12/ 
- ~~set up publishing with OpenID Connect(POSTPONED)~~