### PR TITLE
chore: Compile Deno validator and package in wheels for PyPI

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,6 +38,7 @@ jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: [build_sdist]
     strategy:
       matrix:
         os:
@@ -52,11 +53,18 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Download sdist
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
+          name: Packages
+          path: dist
 
-      - name: Build wheels
+      - name: Unpack sdist
+        run: |
+          tar --strip-components=1 -xzvf dist/*.tar.gz
+          rm -r dist
+
+      - name: Build wheels from sdist
         uses: pypa/cibuildwheel@v2.23
 
       - name: Generate artifact attestation for wheels
@@ -74,7 +82,7 @@ jobs:
     name: Push package to test.pypi.org
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    needs: [build_sdist, build_wheels]
+    needs: [build_wheels]
     permissions:
       id-token: write
 
@@ -105,7 +113,7 @@ jobs:
     name: Publish released package to pypi.org
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
-    needs: [build_sdist, build_wheels]
+    needs: [build_wheels]
     permissions:
       id-token: write
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,130 @@
+name: Build wheels
+
+on:
+  push:
+    branches: [main, dev]
+    tags: ['*']
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MACOSX_DEPLOYMENT_TARGET: '10.12'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build_sdist:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: hynek/build-and-inspect-python-package@v2
+        with:
+          attest-build-provenance-github: ${{ github.event_name != 'pull_request' }}
+          skip-wheel: true
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - windows-latest
+          - macos-13
+          - macos-latest
+      fail-fast: false
+    permissions:
+      attestations: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.23
+
+      - name: Generate artifact attestation for wheels
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+        with:
+          subject-path: "wheelhouse/bids_validator_deno-*.whl"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}
+          path: ./wheelhouse
+
+  test-publish:
+    name: Push package to test.pypi.org
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: [build_sdist, build_wheels]
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wheel-*
+          path: dist
+
+      - run: |
+          mv dist/*/* dist/
+          rmdir dist/*/
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish:
+    name: Publish released package to pypi.org
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    needs: [build_sdist, build_wheels]
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: wheel-*
+          path: dist
+
+      - run: |
+          mv dist/*/* dist/
+          rmdir dist/*/
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ deno run -ERWN jsr:@bids/validator
 ```
 
 Deno by default sandboxes applications like a web browser.
-`-E`, `-R`, '-W', and `-N` allow the validator to read environment variables,
+`-E`, `-R`, `-W`, and `-N` allow the validator to read environment variables,
 read/write local files, and read network locations.
+
+A pre-compiled binary is published to [PyPI][] and may be installed with:
+
+```
+pip install bids-validator-deno
+bids-validator-deno --help
+```
 
 ### Configuration file
 
@@ -91,3 +98,4 @@ The BIDS validator documentation is available on [Read the Docs](https://bids-va
 [BIDS Validator]: https://bids-standard.github.io/bids-validator/
 [Deno]: https://deno.com/
 [Deno - Installation]: https://docs.deno.com/runtime/getting_started/installation/
+[PyPI]: https://pypi.org/project/bids-validator-deno/

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -1,0 +1,35 @@
+import shutil
+import subprocess
+import sysconfig
+
+
+def pdm_build_hook_enabled(context):
+    # Disable hooks for sdist builds
+    return context.target != "sdist"
+
+
+def pdm_build_initialize(context):
+    context.ensure_build_dir()
+    # Inject compiled binary into scripts/, so it will be picked up to install
+    target = context.root / "scripts" / "bids-validator-deno"
+
+    deno = shutil.which("deno")
+    if deno is None:
+        raise OSError("Deno is not installed or not in PATH")
+
+    subprocess.run(
+        [
+            deno,
+            "compile",
+            "-ERNW",
+            "--allow-run",
+            "-o",
+            str(target),
+            "src/bids-validator.ts",
+        ],
+        check=True,
+    )
+
+    # Add the current platform tag so the wheel is specific to the OS/architecture
+    platform_tag = sysconfig.get_platform().replace("-", "_").replace(".", "_")
+    context.config_settings["--plat-name"] = platform_tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,24 @@ scripts = ["scripts/*"]
 
 [tool.pdm.version]
 source = "scm"
+
+[tool.cibuildwheel]
+build = "cp39-*"
+# Deno requires glibc, so the alpine package doesn't give us musllinux yet
+# Deno will not build for 32-bit architectures
+skip = "*musllinux* *_i686 *-win32"
+build-frontend = "build"
+
+manylinux-x86_64-image = "quay.io/pypa/manylinux_2_24_x86_64:latest"
+manylinux-aarch64-image = "quay.io/pypa/manylinux_2_24_aarch64:latest"
+
+before-build = "curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh && deno --version"
+test-command = "bids-validator-deno --version"
+
+[[tool.cibuildwheel.overrides]]
+select = "*musllinux*"
+before-build = 'apk add deno'
+
+[[tool.cibuildwheel.overrides]]
+select = "*win*"
+before-build = 'npm install -g deno & deno --version'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,40 @@
+[project]
+name = "bids-validator-deno"
+description = "Typescript implementation of the BIDS validator"
+authors = [
+    {name = "bids-standard developers"},
+]
+dependencies = []
+readme = "README.md"
+license = {text = "MIT"}
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: JavaScript",
+]
+keywords = ["BIDS", "BIDS validator"]
+dynamic = ["version"]
+
+[project.urls]
+Documentation = "https://bids-validator.readthedocs.io/"
+"Source code" = "https://github.com/bids-standard/bids-validator"
+Issues = "https://github.com/bids-standard/bids-validator/issues"
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
+
+[tool.pdm]
+distribution = true
+
+[tool.pdm.build]
+source-includes = ["src/", "deno.json"]
+excludes = [".*"]
+
+[tool.pdm.build.wheel-data]
+scripts = ["scripts/*"]
+
+[tool.pdm.version]
+source = "scm"


### PR DESCRIPTION
#181 is a bit dissatisfying in that it requires a deno compile step, followed by a python packaging step. While this works for `python -m build --wheel`, it fails for `uv build --wheel`, which attempts to create an sdist and then build the wheel from it. Additionally, it would be nice for `python -m build` and `uv build` to just work.

I was curious to see if you could build an sdist with typescript sources, and pdm required essentially no configuration to achieve that. Compiling the binary and dumping it somewhere that pdm could find to package took some more working out, but turned out not to be too hard. With that, we can publish both sdist and wheel, and users with working `deno` installations can build their own, if our wheels don't cover them.

This uses https://github.com/hynek/build-and-inspect-python-package to package the sdist, and https://github.com/pypa/cibuildwheel to build and test the wheels across architectures. (When a musl version of deno starts being packaged for alpine, we can start building musllinux packages.) This also uses https://github.com/pypa/gh-action-pypi-publish which does OIDC publishing and publishes signed checksums.

Closes #181.