### PR TITLE
use exit code 16 on exit with validation errors per bids apps spec

### DIFF
--- a/changelog.d/20250411_093755_rosswilsonblair_191_update_exit_code.md
+++ b/changelog.d/20250411_093755_rosswilsonblair_191_update_exit_code.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Validator now returns exit code 16 instead of 1 for validation of a dataset with errors.
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/bids-validator.ts
+++ b/src/bids-validator.ts
@@ -4,5 +4,5 @@ const result = await main()
 
 const errors = result.issues.get({ severity: 'error' })
 if (errors.length) {
-  Deno.exit(1)
+  Deno.exit(16)
 }


### PR DESCRIPTION
Exit code of 2 on `--help` seems to be coming from cliffy, leaving as is with the assumption no one is relying on the exit code from the help output for anything. fixes #191