### PR TITLE
fix: Skip sidecar checks for text files

### DIFF
--- a/changelog.d/20250509_080014_markiewicz_bad_sidecars.md
+++ b/changelog.d/20250509_080014_markiewicz_bad_sidecars.md
@@ -1,0 +1,51 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- Sidecar checks are skipped for text files that should not have sidecars.
+  This resolves a problem in derivative datasets, where BIDS specifies a
+  RECOMMENDED field of `Description` in all derivative files. ([#202])
+
+[#202]: https://github.com/bids-standard/bids-validator/issues/202
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -181,7 +181,9 @@ function evalJsonCheck(
   const sidecarRule = schemaPath.match(/rules\.sidecar/)
   // Sidecar rules apply specifically to data files, as JSON files cannot have sidecars
   // Count on other JSON rules to use selectors to match the correct files
-  if (context.extension === '.json' && sidecarRule) return
+  // Text files at the root do not have sidecars. We might want a cleaner
+  // or more schematic way to identify them in the future.
+  if (sidecarRule && (['.json', '', '.md', '.txt', '.rst', '.cff'].includes(context.extension))) return
 
   const json: Record<string, any> = sidecarRule ? context.sidecar : context.json
   for (const [key, requirement] of Object.entries(rule.fields)) {


### PR DESCRIPTION
In #202, `dataset_description.json` and `README.md` were being checked for sidecar fields `Description` because of a rule that applies to all derivatives. However, these files cannot have sidecars, so we need a way to detect them.

The `readEntities()` function tags `README.md` with a suffix of "README", and `dataset_description.json` with a suffix of `description`, along with their extensions, but, when we run filenameIdentify, we clean the context of components that don't apply to any rules:

https://github.com/bids-standard/bids-validator/blob/d80712956b07f4346b26952e5580cd3ff3bf37b8/src/validators/filenameIdentify.ts#L221-L237

Therefore `dataset_description.json` loses its suffix and extension, which is why sidecar checking wasn't disabled. `README.md`, or any other text file, were checked because they weren't `.json` files, so we need to skip these text files.

Fortunately, there aren't any file rules that use these extensions for files that can have sidecars, but we'll probably a better way to handle this long-term.