### PR TITLE
Raise error when json files are parsed and their root value is an array instead of object.

### DIFF
--- a/changelog.d/20250808_135941_rosswilsonblair_raise_error_on_non_object_json.md
+++ b/changelog.d/20250808_135941_rosswilsonblair_raise_error_on_non_object_json.md
@@ -13,7 +13,7 @@ For top level release notes, leave all the headers commented out.
 -->
 ### Changed
 
-- Raise error when json files are parsed and their root value is an array instead of object
+- Raise error when JSON files are parsed and their root value is anything other than an object
 
 <!--
 ### Fixed

--- a/changelog.d/20250808_135941_rosswilsonblair_raise_error_on_non_object_json.md
+++ b/changelog.d/20250808_135941_rosswilsonblair_raise_error_on_non_object_json.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Raise error when json files are parsed and their root value is an array instead of object
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/files/json.ts
+++ b/src/files/json.ts
@@ -28,7 +28,7 @@ export async function loadJSON(file: BIDSFile): Promise<Record<string, unknown>>
   } catch (error) {
     throw { key: 'JSON_INVALID' } // Raise syntax errors
   }
-  if (Array.isArray(parsedText)) {
+  if (Array.isArray(parsedText) || typeof parsedText !== "object") {
     throw { key: 'JSON_NOT_AN_OBJECT' }
   }
   return parsedText

--- a/src/files/json.ts
+++ b/src/files/json.ts
@@ -22,9 +22,14 @@ async function readJSONText(file: BIDSFile): Promise<string> {
 
 export async function loadJSON(file: BIDSFile): Promise<Record<string, unknown>> {
   const text = await readJSONText(file) // Raise encoding errors
+  let parsedText;
   try {
-    return JSON.parse(text)
+    parsedText = JSON.parse(text)
   } catch (error) {
     throw { key: 'JSON_INVALID' } // Raise syntax errors
   }
+  if (Array.isArray(parsedText)) {
+    throw { key: 'JSON_NOT_AN_OBJECT' }
+  }
+  return parsedText
 }

--- a/src/files/json.ts
+++ b/src/files/json.ts
@@ -29,7 +29,7 @@ export async function loadJSON(file: BIDSFile): Promise<Record<string, unknown>>
     throw { key: 'JSON_INVALID' } // Raise syntax errors
   }
   if (Array.isArray(parsedText) || typeof parsedText !== "object") {
-    throw { key: 'JSON_NOT_AN_OBJECT' }
+    throw { key: 'JSON_NOT_AN_OBJECT', evidence: text.substring(0, 10) + (text.length > 10 ? '...' : '') }
   }
   return parsedText
 }

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -11,7 +11,7 @@ export const bidsIssues: IssueDefinitionRecord = {
   },
   JSON_NOT_AN_OBJECT: {
     severity: 'error',
-    reason: 'Parsed json file contains an array as its root element and not an object.',
+    reason: 'Parsed JSON file does not contain an object.',
   },
   MISSING_DATASET_DESCRIPTION: {
     severity: 'error',

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -9,6 +9,10 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'Not a valid JSON file.',
   },
+  JSON_NOT_AN_OBJECT: {
+    severity: 'error',
+    reason: 'Parsed json file contains an array as its root element and not an object.',
+  },
   MISSING_DATASET_DESCRIPTION: {
     severity: 'error',
     reason: 'A dataset_description.json file is required in the root of the dataset',


### PR DESCRIPTION
fixes #178

This is being thrown on sidecar loading so could generate a large number of errors for an inherited file.