### PR TITLE
feat: Add DatasetType passlist to allow applications to limit support

### DIFF
--- a/changelog.d/20250825_075606_markiewicz_dataset_types.md
+++ b/changelog.d/20250825_075606_markiewicz_dataset_types.md
@@ -1,0 +1,49 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Added
+
+- The `--datasetTypes` flag accepts a list of `DatasetType`s,
+  allowing applications to restrict the datasets they accept.
+
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -170,6 +170,10 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'A json sidecar file was found without a corresponding data file',
   },
+  UNSUPPORTED_DATASET_TYPE: {
+    severity: 'error',
+    reason: 'This DatasetType is not supported by the application.',
+  },
   BLACKLISTED_MODALITY: {
     severity: 'error',
     reason: 'The modality in this file is blacklisted through validator configuration.',

--- a/src/setup/options.test.ts
+++ b/src/setup/options.test.ts
@@ -10,6 +10,7 @@ Deno.test('options parsing', async (t) => {
       json: true,
       color: false,
       blacklistModalities: [],
+      datasetTypes: [],
       maxRows: 1000,
     })
   })

--- a/src/setup/options.ts
+++ b/src/setup/options.ts
@@ -28,10 +28,15 @@ export type ValidatorOptions = {
   color?: boolean
   recursive?: boolean
   outfile?: string
+  datasetTypes: string[]
   blacklistModalities: string[]
   prune?: boolean
   maxRows?: number
 }
+
+const datasetType = new EnumType<string>(
+  schema.objects.metadata.DatasetType.enum as string[],
+)
 
 const modalityType = new EnumType<string>(
   Object.keys(schema.rules.modalities),
@@ -68,6 +73,12 @@ export const validateCommand: Command<void, void, any, string[], void> = new Com
   .option(
     '--filenameMode',
     'Enable filename checks for newline separated filenames read from stdin',
+  )
+  .type('datasetType', datasetType)
+  .option(
+    '--datasetTypes <...datasetTypes:datasetType>',
+    'Permitted dataset types to validate against (default: all)',
+    { default: [] as string[] },
   )
   .type('modality', modalityType)
   .option(

--- a/src/tests/regression.test.ts
+++ b/src/tests/regression.test.ts
@@ -24,6 +24,7 @@ Deno.test('Regression tests', async (t) => {
       debug: 'ERROR',
       ignoreNiftiHeaders: true,
       blacklistModalities: [],
+      datasetTypes: [],
     })
     assert(result.issues.get({ code: 'NOT_INCLUDED' }).length == 1)
     assert(result.issues.get({ code: 'SCANS_FILENAME_NOT_MATCH_DATASET' }).length == 0)
@@ -37,6 +38,7 @@ Deno.test('Regression tests', async (t) => {
       debug: 'ERROR',
       ignoreNiftiHeaders: true,
       blacklistModalities: [],
+      datasetTypes: [],
     })
     assert(result.issues.get({ code: 'NOT_INCLUDED' }).length == 0)
     assert(result.issues.get({ code: 'SCANS_FILENAME_NOT_MATCH_DATASET' }).length == 0)

--- a/src/validators/bids.test.ts
+++ b/src/validators/bids.test.ts
@@ -14,6 +14,7 @@ Deno.test('Smoke tests of main validation function', async (t) => {
       debug: 'INFO',
       ignoreNiftiHeaders: true,
       blacklistModalities: [],
+      datasetTypes: [],
     })
     assert(result.issues.get({ code: 'BLACKLISTED_MODALITY' }).length === 0)
 
@@ -22,6 +23,7 @@ Deno.test('Smoke tests of main validation function', async (t) => {
       debug: 'INFO',
       ignoreNiftiHeaders: true,
       blacklistModalities: ['MRI'],
+      datasetTypes: [],
     })
     assert(result.issues.get({ code: 'BLACKLISTED_MODALITY' }).length === 1)
 
@@ -30,6 +32,7 @@ Deno.test('Smoke tests of main validation function', async (t) => {
       debug: 'INFO',
       ignoreNiftiHeaders: true,
       blacklistModalities: ['MEG'],
+      datasetTypes: [],
     })
     assert(result.issues.get({ code: 'BLACKLISTED_MODALITY' }).length === 0)
 
@@ -38,6 +41,7 @@ Deno.test('Smoke tests of main validation function', async (t) => {
       debug: 'INFO',
       ignoreNiftiHeaders: true,
       blacklistModalities: ['MEG', 'MRI'],
+      datasetTypes: [],
     })
     assert(result.issues.get({ code: 'BLACKLISTED_MODALITY' }).length === 1)
   })
@@ -48,6 +52,7 @@ Deno.test('Smoke tests of main validation function', async (t) => {
         datasetPath: '/dataset',
         debug: 'INFO',
         blacklistModalities: [],
+        datasetTypes: [],
       },
       {
         ignore: [{ location: '/dataset_description.json' }],

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -72,6 +72,18 @@ export async function validate(
     })
   }
 
+  // Empty list defaults to allow all
+  if (options.datasetTypes.length) {
+    const datasetType = (dsContext.dataset_description.DatasetType ?? 'raw') as string
+    if (!options.datasetTypes.includes(datasetType)) {
+      dsContext.issues.add({
+        code: 'UNSUPPORTED_DATASET_TYPE',
+        location: '/dataset_description.json',
+        issueMessage: `"DatasetType": "${datasetType}"`,
+      })
+    }
+  }
+
   const bidsDerivatives: FileTree[] = []
   const nonstdDerivatives: FileTree[] = []
   fileTree.directories = fileTree.directories.filter((dir) => {


### PR DESCRIPTION
Closes #229. I went with a pass-list so that we can say `datasetTypes: ['raw', 'derivative']` in OpenNeuro without waiting on `'study'` to be a valid value to disallow it.