### PR TITLE
chore: Reenable DockerHub pushes

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5
+        with:
+          fetch-tags: true
+          fetch-depth: 200
+          filter: blob:none
 
       - name: Log in to Docker Hub
         if: github.event_name == 'push'
@@ -43,3 +47,6 @@ jobs:
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Verify docker image
+        run: docker run --rm ${{ steps.meta.outputs.tags }} --version

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,45 @@
+name: Docker
+
+on:
+  push:
+    branches: [main, dev]
+    tags: ['*']
+  pull_request:
+    branches: [main, dev]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: bids/validator
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           images: bids/validator
 
-      - name: Build and push Docker image
+      - name: Build ${{ startsWith(github.ref, 'refs/tags/') && 'and push' || '' }} ${{ steps.meta.outputs.tags }}
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -48,5 +48,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Verify docker image
+      - name: Verify Docker image
         run: docker run --rm ${{ steps.meta.outputs.tags }} --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,15 @@
-ARG BASE_IMAGE=denoland/deno:2.4.5
+ARG BASE_IMAGE=denoland/deno:alpine-2.4.5
 FROM ${BASE_IMAGE} AS build
 WORKDIR /src
 
-RUN apt-get update && \
-    apt-get install -y git jq && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache git jq
 
 ADD . .
 RUN export VERSION=`git -C . -c safe.directory=* describe --tags --always` && \
     jq -r ".version|=\"$VERSION\"" deno.json > ._deno.json && \
     mv ._deno.json deno.json
 
-RUN ./build.ts
+RUN deno run -A ./build.ts
 
 FROM ${BASE_IMAGE} AS min
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=denoland/deno:2.0.1
+ARG BASE_IMAGE=denoland/deno:2.4.5
 FROM ${BASE_IMAGE} AS build
 WORKDIR /src
 
@@ -9,22 +9,13 @@ RUN apt-get update && \
 
 ADD . .
 RUN export VERSION=`git -C . -c safe.directory=* describe --tags --always` && \
-    jq -r ".version|=\"$VERSION\"" bids-validator/deno.json > ._deno.json
+    jq -r ".version|=\"$VERSION\"" deno.json > ._deno.json && \
+    mv ._deno.json deno.json
 
-WORKDIR /src/bids-validator
-RUN deno cache ./bids-validator-deno
 RUN ./build.ts
-
-FROM ${BASE_IMAGE} AS base
-WORKDIR /src
-COPY . .
-COPY --from=build /src/._deno.json /src/bids-validator/deno.json
-WORKDIR /src/bids-validator
-RUN deno cache ./bids-validator-deno
-ENTRYPOINT ["./bids-validator-deno"]
 
 FROM ${BASE_IMAGE} AS min
 WORKDIR /src
-COPY --from=build /src/bids-validator/dist/validator/* .
+COPY --from=build /src/dist/validator/bids-validator.js .
 
 ENTRYPOINT ["deno", "-A", "./bids-validator.js"]

--- a/changelog.d/20250826_074930_markiewicz_docker.md
+++ b/changelog.d/20250826_074930_markiewicz_docker.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+### Infrastructure
+
+- Docker images will once again be pushed to [bids/validator][].
+
+[bids/validator]: https://hub.docker.com/r/bids/validator/


### PR DESCRIPTION
This PR reenables DockerHub pushes. This request has come up enough times that I suppose it's worth doing.

Using alpine to slim down the container as much as possible. It's still 150MB or so locally, but that's better than 220.

No attempt is made to do multi-architecture builds. Will open an issue.