### PR TITLE
 feat: Enable type checking on tsv.gz files

### DIFF
--- a/changelog.d/20250828_104256_markiewicz_tsv_gz.md
+++ b/changelog.d/20250828_104256_markiewicz_tsv_gz.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Added
+
+- Load `.tsv.gz` column contents for validation.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/files/tsv.test.ts
+++ b/src/files/tsv.test.ts
@@ -64,7 +64,7 @@ Deno.test('TSV loading', async (t) => {
     try {
       await loadTSV(file)
     } catch (e: any) {
-      assertObjectMatch(e, { code: 'TSV_EQUAL_ROWS', location: '/mismatched_row.tsv', line: 3 })
+      assertObjectMatch(e, { code: 'TSV_EQUAL_ROWS', line: 3 })
     }
   })
 

--- a/src/files/tsv.ts
+++ b/src/files/tsv.ts
@@ -8,6 +8,47 @@ import type { BIDSFile } from '../types/filetree.ts'
 import { filememoizeAsync } from '../utils/memoize.ts'
 import { createUTF8Stream } from './streams.ts'
 
+async function loadColumns(
+  reader: ReadableStreamDefaultReader<string>,
+  headers: string[],
+  maxRows: number,
+): Promise<ColumnsMap> {
+  // Initialize columns in array for construction efficiency
+  const initialCapacity = maxRows >= 0 ? maxRows : 1000
+  const columns: string[][] = headers.map(() => new Array<string>(initialCapacity))
+
+  maxRows = maxRows >= 0 ? maxRows : Infinity
+  let rowIndex = 0 // Keep in scope after loop
+  for (; rowIndex < maxRows; rowIndex++) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    // Expect a newline at the end of the file, but otherwise error on empty lines
+    if (!value) {
+      const nextRow = await reader.read()
+      if (nextRow.done) break
+      throw { code: 'TSV_EMPTY_LINE', line: rowIndex + 2 }
+    }
+
+    const values = value.split('\t')
+    if (values.length !== headers.length) {
+      throw { code: 'TSV_EQUAL_ROWS', line: rowIndex + 2 }
+    }
+    columns.forEach((column, columnIndex) => {
+      // Double array size if we exceed the current capacity
+      if (rowIndex >= column.length) {
+        column.length = column.length * 2
+      }
+      column[rowIndex] = values[columnIndex]
+    })
+  }
+
+  // Construct map, truncating columns to number of rows read
+  return new ColumnsMap(
+    headers.map((header, index) => [header, columns[index].slice(0, rowIndex)]),
+  )
+}
+
 async function _loadTSV(file: BIDSFile, maxRows: number = -1): Promise<ColumnsMap> {
   const reader = file.stream
     .pipeThrough(createUTF8Stream())
@@ -26,40 +67,7 @@ async function _loadTSV(file: BIDSFile, maxRows: number = -1): Promise<ColumnsMa
       }
     }
 
-    // Initialize columns in array for construction efficiency
-    const initialCapacity = maxRows >= 0 ? maxRows : 1000
-    const columns: string[][] = headers.map(() => new Array<string>(initialCapacity))
-
-    maxRows = maxRows >= 0 ? maxRows : Infinity
-    let rowIndex = 0 // Keep in scope after loop
-    for (; rowIndex < maxRows; rowIndex++) {
-      const { done, value } = await reader.read()
-      if (done) break
-
-      // Expect a newline at the end of the file, but otherwise error on empty lines
-      if (!value) {
-        const nextRow = await reader.read()
-        if (nextRow.done) break
-        throw { code: 'TSV_EMPTY_LINE', location: file.path, line: rowIndex + 2 }
-      }
-
-      const values = value.split('\t')
-      if (values.length !== headers.length) {
-        throw { code: 'TSV_EQUAL_ROWS', location: file.path, line: rowIndex + 2 }
-      }
-      columns.forEach((column, columnIndex) => {
-        // Double array size if we exceed the current capacity
-        if (rowIndex >= column.length) {
-          column.length = column.length * 2
-        }
-        column[rowIndex] = values[columnIndex]
-      })
-    }
-
-    // Construct map, truncating columns to number of rows read
-    return new ColumnsMap(
-      headers.map((header, index) => [header, columns[index].slice(0, rowIndex)]),
-    )
+    return await loadColumns(reader, headers, maxRows)
   } finally {
     await reader.cancel()
   }

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -133,6 +133,10 @@ export const bidsIssues: IssueDefinitionRecord = {
     reason:
       'A column required in a TSV file has been redefined in a sidecar file. This redefinition is being ignored.',
   },
+  INVALID_GZIP: {
+    severity: 'error',
+    reason: 'The gzip file could not be decompressed. It may be corrupt or misnamed.',
+  },
   MULTIPLE_INHERITABLE_FILES: {
     severity: 'error',
     reason: 'Multiple files in a directory were found to be valid candidates for inheritance.',

--- a/src/schema/tables.ts
+++ b/src/schema/tables.ts
@@ -207,7 +207,7 @@ export function evalColumns(
   schema: Schema,
   schemaPath: string,
 ): void {
-  if (!rule.columns || context.extension !== '.tsv') return
+  if (!rule.columns || !['.tsv', '.tsv.gz'].includes(context.extension)) return
   const headers = [...Object.keys(context.columns)]
   for (const [ruleHeader, requirement] of Object.entries(rule.columns)) {
     const columnObject: ColumnSchema = schema.objects.columns[ruleHeader]
@@ -284,7 +284,7 @@ export function evalInitialColumns(
   schemaPath: string,
 ): void {
   if (
-    !rule?.columns || !rule?.initial_columns || context.extension !== '.tsv'
+    !rule?.columns || !rule?.initial_columns || !['.tsv', '.tsv.gz'].includes(context.extension)
   ) {
     return
   }
@@ -318,7 +318,7 @@ export function evalAdditionalColumns(
   schema: Schema,
   schemaPath: string,
 ): void {
-  if (context.extension !== '.tsv') return
+  if (!['.tsv', '.tsv.gz'].includes(context.extension)) return
   const headers = Object.keys(context?.columns)
   if (rule.columns) {
     if (!rule.additional_columns || rule.additional_columns === 'n/a') {
@@ -362,7 +362,7 @@ export function evalIndexColumns(
     !rule?.columns ||
     !rule?.index_columns ||
     !rule?.index_columns.length ||
-    context.extension !== '.tsv'
+    !['.tsv', '.tsv.gz'].includes(context.extension)
   ) {
     return
   }


### PR DESCRIPTION
~~Partially addresses #239 by loading data for validation. I think we need #234 in before I start debugging validation itself, since that reworks it so significantly.~~

Closes #239. This currently only generates a warning, but that's because all non-required columns emit warnings instead of errors. I would like to change them to errors, but that's a separate PR.