### PR TITLE
feat: Split out deprecation warning for age=="89+"

### DIFF
--- a/changelog.d/20250828_161028_markiewicz_deprecate_89plus.md
+++ b/changelog.d/20250828_161028_markiewicz_deprecate_89plus.md
@@ -1,0 +1,50 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Added
+
+- Issue deprecation warning for `"89+"` in `age` columns, per
+  [bids-standard/bids-specification#2162][].
+
+[bids-standard/bids-specification#2162]: https://github.com/bids-standard/bids-specification/pull/2162
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -133,6 +133,10 @@ export const bidsIssues: IssueDefinitionRecord = {
     reason:
       'A column required in a TSV file has been redefined in a sidecar file. This redefinition is being ignored.',
   },
+  TSV_PSEUDO_AGE_DEPRECATED: {
+    severity: 'warning',
+    reason: 'Use of the value "89+" in column "age" is deprecated. Use 89 for all ages 89 and over.',
+  },
   INVALID_GZIP: {
     severity: 'error',
     reason: 'The gzip file could not be decompressed. It may be corrupt or misnamed.',

--- a/src/schema/tables.test.ts
+++ b/src/schema/tables.test.ts
@@ -166,6 +166,25 @@ Deno.test('tables eval* tests', async (t) => {
     assertEquals(issues[0].issueMessage, "'f'")
   })
 
+  await t.step('verify pseudo-age deprecation', () => {
+    const context = {
+      path: '/participants.tsv',
+      extension: '.tsv',
+      sidecar: {},
+      columns: {
+        participant_id: ['sub-01', 'sub-02', 'sub-03'],
+        age: ['10', '89+', '89+'],
+      },
+      dataset: { issues: new DatasetIssues() },
+    }
+    const rule = schemaDefs.rules.tabular_data.modality_agnostic.Participants
+    evalColumns(rule, context, schema, 'rules.tabular_data.modality_agnostic.Participants')
+
+    // age gets a warning
+    let issues = context.dataset.issues.get({ code: 'TSV_PSEUDO_AGE_DEPRECATED' })
+    assertEquals(issues.length, 1)
+  })
+
   await t.step('verify column ordering', () => {
     const context = {
       path: '/sub-01/sub-01_scans.tsv',

--- a/src/schema/tables.ts
+++ b/src/schema/tables.ts
@@ -257,7 +257,7 @@ export function evalColumns(
       rule: schemaPath,
     }
 
-    const ageCheck = name == 'age'
+    const ageCheck = name === 'age'
     let ageWarningIssued = false
 
     const column = context.columns[name] as string[]

--- a/src/schema/tables.ts
+++ b/src/schema/tables.ts
@@ -257,9 +257,23 @@ export function evalColumns(
       rule: schemaPath,
     }
 
+    const ageCheck = name == 'age'
+    let ageWarningIssued = false
+
     const column = context.columns[name] as string[]
     for (const [index, value] of column.entries()) {
       if (!checkValue(value, spec)) {
+        if (ageCheck && value === '89+') {
+          if (!ageWarningIssued) {
+            ageWarningIssued = true
+            context.dataset.issues.add({
+              code: 'TSV_PSEUDO_AGE_DEPRECATED',
+              location: context.path,
+              line: index + 2,
+            })
+          }
+          continue
+        }
         const issueMessage = `'${value}'` +
           (value.match(/^\s*(NA|na|nan|NaN|n\/a)\s*$/) ? ", did you mean 'n/a'?" : '')
         context.dataset.issues.add({


### PR DESCRIPTION
This allows 89+ to be used in age columns, regardless of whether we start raising errors for optional columns.