### PR TITLE
feat: Always error on incorrect TSV types

### DIFF
--- a/changelog.d/20250828_163229_markiewicz_tsv_type_errors.md
+++ b/changelog.d/20250828_163229_markiewicz_tsv_type_errors.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+### Changed
+
+- Raise errors for all TSV type check failures.
+  Previously, recommended and optional fields would raise warnings.
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -123,11 +123,6 @@ export const bidsIssues: IssueDefinitionRecord = {
     reason:
       'A value in a column did not match the acceptable type for that column headers specified format.',
   },
-  TSV_VALUE_INCORRECT_TYPE_NONREQUIRED: {
-    severity: 'warning',
-    reason:
-      'A value in a column did not match the acceptable type for that column headers specified format.',
-  },
   TSV_COLUMN_TYPE_REDEFINED: {
     severity: 'warning',
     reason:

--- a/src/schema/tables.test.ts
+++ b/src/schema/tables.test.ts
@@ -69,7 +69,7 @@ Deno.test('tables eval* tests', async (t) => {
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Scans
     evalColumns(rule, context, schema, 'rules.tabular_data.modality_agnostic.Scans')
     assertEquals(
-      context.dataset.issues.get({ code: 'TSV_VALUE_INCORRECT_TYPE_NONREQUIRED' }).length,
+      context.dataset.issues.get({ code: 'TSV_VALUE_INCORRECT_TYPE' }).length,
       1,
     )
   })
@@ -159,7 +159,7 @@ Deno.test('tables eval* tests', async (t) => {
 
     // Overriding the default sex definition uses the provided values
     // Values in the default definition may raise issues
-    issues = context.dataset.issues.get({ code: 'TSV_VALUE_INCORRECT_TYPE_NONREQUIRED' })
+    issues = context.dataset.issues.get({ code: 'TSV_VALUE_INCORRECT_TYPE' })
     assertEquals(issues.length, 1)
     assertEquals(issues[0].subCode, 'sex')
     assertEquals(issues[0].line, 4)

--- a/src/schema/tables.ts
+++ b/src/schema/tables.ts
@@ -251,7 +251,7 @@ export function evalColumns(
     const spec = compileSignature(signature, schema.objects.formats)
 
     const issue = {
-      code: 'TSV_VALUE_INCORRECT_TYPE' + (requirement != 'required' ? '_NONREQUIRED' : ''),
+      code: 'TSV_VALUE_INCORRECT_TYPE',
       subCode: name,
       location: context.path,
       rule: schemaPath,


### PR DESCRIPTION
Following #234, it is always possible to define a type precisely in a sidecar definition. It is therefore safe to error when types don't match, because the solution is "Improve the type of your column."

Builds on #240 