### PR TITLE
chore: Bump schema to 1.1.0

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -28,7 +28,7 @@
   },
   "imports": {
     "@ajv": "npm:ajv@8.17.1",
-    "@bids/schema": "jsr:@bids/schema@~1.1.0-dev.43+135cc18d",
+    "@bids/schema": "jsr:@bids/schema@~1.1.0",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
     "@hed/validator": "npm:hed-validator@4.0.1",

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@bids/schema@~1.1.0-dev.43+135cc18d": "1.1.0-dev.43+135cc18d",
+    "jsr:@bids/schema@1.1": "1.1.0",
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
@@ -16,18 +16,18 @@
     "jsr:@std/bytes@^1.0.2": "1.0.5",
     "jsr:@std/bytes@^1.0.2-rc.3": "1.0.2",
     "jsr:@std/bytes@^1.0.3": "1.0.5",
-    "jsr:@std/bytes@^1.0.5": "1.0.5",
+    "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/encoding@0.213": "0.213.1",
     "jsr:@std/encoding@^1.0.5": "1.0.5",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fmt@1.0.5": "1.0.5",
     "jsr:@std/fmt@1.0.6": "1.0.6",
     "jsr:@std/fmt@^1.0.2": "1.0.3",
-    "jsr:@std/fmt@^1.0.5": "1.0.8",
-    "jsr:@std/fmt@~1.0.2": "1.0.5",
+    "jsr:@std/fmt@^1.0.5": "1.0.6",
+    "jsr:@std/fmt@~1.0.2": "1.0.6",
     "jsr:@std/fs@1.0.13": "1.0.13",
     "jsr:@std/fs@1.0.15": "1.0.15",
-    "jsr:@std/fs@^1.0.11": "1.0.19",
+    "jsr:@std/fs@^1.0.11": "1.0.15",
     "jsr:@std/internal@^1.0.6": "1.0.10",
     "jsr:@std/internal@^1.0.9": "1.0.10",
     "jsr:@std/io@0.225.2": "0.225.2",
@@ -38,11 +38,11 @@
     "jsr:@std/path@1.0.8": "1.0.8",
     "jsr:@std/path@^1.0.6": "1.0.6",
     "jsr:@std/path@^1.0.7": "1.0.8",
-    "jsr:@std/path@^1.0.8": "1.1.1",
+    "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/path@^1.1.1": "1.1.1",
     "jsr:@std/streams@1.0.9": "1.0.9",
-    "jsr:@std/text@~1.0.7": "1.0.10",
-    "jsr:@std/yaml@^1.0.5": "1.0.5",
+    "jsr:@std/text@~1.0.7": "1.0.16",
+    "jsr:@std/yaml@^1.0.5": "1.0.9",
     "npm:@bids/nifti-reader-js@0.6.9": "0.6.9",
     "npm:@types/node@*": "22.15.15",
     "npm:ajv@8.17.1": "8.17.1",
@@ -50,8 +50,8 @@
     "npm:ignore@7.0.3": "7.0.3"
   },
   "jsr": {
-    "@bids/schema@1.1.0-dev.43+135cc18d": {
-      "integrity": "47c20437ed7216173a80976623134591eb2eb19c8309aee1c9921ac3a3405769"
+    "@bids/schema@1.1.0": {
+      "integrity": "7687c6fc3fdaaec8bba0c21b09e98175167d20e97ddaa29c03af8d2551f95fcd"
     },
     "@cliffy/flags@1.0.0-rc.7": {
       "integrity": "318d9be98f6a6417b108e03dec427dea96cdd41a15beb21d2554ae6da450a781",
@@ -118,6 +118,9 @@
     },
     "@std/bytes@1.0.5": {
       "integrity": "4465dd739d7963d964c809202ebea6d5c6b8e3829ef25c6a224290fbb8a1021e"
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
     "@std/encoding@0.213.1": {
       "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
@@ -211,8 +214,14 @@
     "@std/text@1.0.10": {
       "integrity": "9dcab377450253c0efa9a9a0c731040bfd4e1c03f8303b5934381467b7954338"
     },
+    "@std/text@1.0.16": {
+      "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
+    },
     "@std/yaml@1.0.5": {
       "integrity": "71ba3d334305ee2149391931508b2c293a8490f94a337eef3a09cade1a2a2742"
+    },
+    "@std/yaml@1.0.9": {
+      "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
     }
   },
   "npm": {
@@ -474,7 +483,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@bids/schema@~1.1.0-dev.43+135cc18d",
+      "jsr:@bids/schema@1.1",
       "jsr:@effigies/cliffy-command@1.0.0-dev.8",
       "jsr:@effigies/cliffy-table@1.0.0-dev.5",
       "jsr:@libs/xml@6.0.4",


### PR DESCRIPTION
Merged `dev` into `main`, and now we should be tracking `~1.1.0` releases.