### PR TITLE
fix: Check index columns

### DIFF
--- a/src/schema/tables.test.ts
+++ b/src/schema/tables.test.ts
@@ -7,6 +7,7 @@ import {
   evalIndexColumns,
   evalInitialColumns,
 } from './tables.ts'
+import { ColumnsMap } from '../types/columns.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 
 const schemaDefs = {
@@ -60,10 +61,10 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/sub-01/sub-01_scans.tsv',
       extension: '.tsv',
       sidecar: {},
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         filename: ['func/sub-01_task-rest_bold.nii.gz'],
         acq_time: ['1900-01-01T00:00:78'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Scans
@@ -79,9 +80,9 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/sub-01/sub-01_something.tsv',
       extension: '.tsv',
       sidecar: {},
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         onset: ['1', '2', 'not a number'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
@@ -94,10 +95,10 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/sub-01/sub-01_something.tsv',
       extension: '.tsv',
       sidecar: {},
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         onset: ['1', '2', 'n/a'],
         strain_rrid: ['RRID:SCR_012345', 'RRID:SCR_012345', 'n/a'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
@@ -138,12 +139,12 @@ Deno.test('tables eval* tests', async (t) => {
         sex: '/participants.json',
         strain_rrid: '/participants.json',
       },
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         participant_id: ['sub-01', 'sub-02', 'sub-03'],
         age: ['10', '20', '30'],
         sex: ['M', 'F', 'f'],
         strain_rrid: ['RRID:SCR_012345', 'RRID:SCR_012345', 'n/a'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Participants
@@ -171,10 +172,10 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/participants.tsv',
       extension: '.tsv',
       sidecar: {},
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         participant_id: ['sub-01', 'sub-02', 'sub-03'],
         age: ['10', '89+', '89+'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Participants
@@ -190,9 +191,9 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/sub-01/sub-01_scans.tsv',
       extension: '.tsv',
       sidecar: {},
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         onset: ['1900-01-01:00:00'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Scans
@@ -219,10 +220,10 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/sub-01/sub-01_scans.tsv',
       extension: '.tsv',
       sidecar: {},
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         onset: ['1900-01-01:00:00', '1900-01-01:00:00'],
         filename: ['func/sub-01_task-rest_bold.nii.gz', 'func/sub-01_task-rest_bold.nii.gz'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.modality_agnostic.Scans
@@ -238,10 +239,10 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/sub-01/sub-01_scans.tsv',
       extension: '.tsv',
       sidecar: {},
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         onset: ['1', '2', 'n/a'],
         strain_rrid: ['RRID:SCR_012345', 'RRID:SCR_012345', 'n/a'],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp
@@ -260,11 +261,11 @@ Deno.test('tables eval* tests', async (t) => {
       path: '/sub-01/sub-01_scans.tsv',
       extension: '.tsv',
       sidecar: { 'extra': { 'description': 'a fun and whimsical extra column' } },
-      columns: {
+      columns: new ColumnsMap(Object.entries({
         onset: ['1', '2', 'n/a'],
         strain_rrid: ['RRID:SCR_012345', 'RRID:SCR_012345', 'n/a'],
         extra: [1, 2, 3],
-      },
+      })),
       dataset: { issues: new DatasetIssues() },
     }
     const rule = schemaDefs.rules.tabular_data.made_up.MadeUp

--- a/src/schema/tables.ts
+++ b/src/schema/tables.ts
@@ -409,7 +409,7 @@ export function evalIndexColumns(
   const uniqueIndexValues = new Set()
   const index_columns = rule.index_columns.map((col: string) => {
     return schema.objects.columns[col].name
-  }).filter((col: string) => col in context.columns)
+  }).filter((col: string) => context.columns[col])
 
   const rowCount = (context.columns[index_columns[0]] as string[])?.length || 0
   for (let i = 0; i < rowCount; i++) {


### PR DESCRIPTION
Accidentally stopped validating index columns at all in #243. Updated tests to catch it by using `ColumnsMap`, which does not work with `x in columns`.