### PR TITLE
chore: Use deno 2.4 in CI

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -38,7 +38,7 @@ jobs:
         run: echo version=$( git describe ) >> $GITHUB_OUTPUT
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.4
       - run: deno --node-modules-dir=auto -A ./build.ts
       - run: deno run -A ./dist/validator/bids-validator.js --version
       - uses: actions/upload-artifact@v4
@@ -64,7 +64,7 @@ jobs:
           submodules: true
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.4
       - name: Set permissions with network access
         run: echo 'PERMS=--allow-read --allow-write --allow-env --allow-run --allow-net' >> $GITHUB_ENV
         if: ${{ matrix.allow-net }}
@@ -98,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.4
       - run: deno publish --dry-run
 
   publish:
@@ -117,7 +117,7 @@ jobs:
           TAG: ${{ github.ref_name }}
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.4
       - run: deno publish
 
   deploy:

--- a/.github/workflows/web_build.yml
+++ b/.github/workflows/web_build.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.4
       - run: deno task build
         working-directory: ./web
       - name: Upload GitHub Pages artifact
@@ -52,7 +52,7 @@ jobs:
           path: dev
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: v2.4
       - name: Build release/target
         run: deno task build
         working-directory: stable/web


### PR DESCRIPTION
Deno released 2.5 with Typescript 5.9.2 in it, which started breaking type checking. Pinning to 2.4 until that's resolved.