### PR TITLE
feat: Add file access functions that translate errors into issues

### DIFF
--- a/changelog.d/20250911_171112_markiewicz_file_access_errors.md
+++ b/changelog.d/20250911_171112_markiewicz_file_access_errors.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- File access failures consistently produce `FILE_READ` errors across all file types.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/files/access.test.ts
+++ b/src/files/access.test.ts
@@ -7,30 +7,34 @@ export function testAsyncFileAccess(
   fn: (file: BIDSFileDeno, ...args: any[]) => Promise<any>,
   ...args: any[]
 ) {
-  Deno.test(name, async (t) => {
-    await t.step('Dangling symlink', async () => {
-      const file = new BIDSFileDeno('tests/data', '/broken-symlink')
-      try {
-        await fn(file, ...args)
-        assert(false, 'Expected error')
-      } catch (e: any) {
-        assertObjectMatch(e, {
-          code: 'FILE_READ',
-          location: '/broken-symlink',
-        })
-        assertArrayIncludes(['NotFound', 'FilesystemLoop'], [e.subCode])
-      }
-    })
-    await t.step('Insufficient permissions', async () => {
-      const tmpfile = await Deno.makeTempFile()
-      await Deno.chmod(tmpfile, 0o000)
-      const file = new BIDSFileDeno('', tmpfile)
-      try {
-        await fn(file, ...args)
-        assert(false, 'Expected error')
-      } catch (e: any) {
-        assertObjectMatch(e, { code: 'FILE_READ', subCode: 'PermissionDenied' })
-      }
-    })
+  Deno.test({
+    name,
+    ignore: Deno.build.os === 'windows',
+    async fn(t) {
+      await t.step('Dangling symlink', async () => {
+        const file = new BIDSFileDeno('tests/data', '/broken-symlink')
+        try {
+          await fn(file, ...args)
+          assert(false, 'Expected error')
+        } catch (e: any) {
+          assertObjectMatch(e, {
+            code: 'FILE_READ',
+            location: '/broken-symlink',
+          })
+          assertArrayIncludes(['NotFound', 'FilesystemLoop'], [e.subCode])
+        }
+      })
+      await t.step('Insufficient permissions', async () => {
+        const tmpfile = await Deno.makeTempFile()
+        await Deno.chmod(tmpfile, 0o000)
+        const file = new BIDSFileDeno('', tmpfile)
+        try {
+          await fn(file, ...args)
+          assert(false, 'Expected error')
+        } catch (e: any) {
+          assertObjectMatch(e, { code: 'FILE_READ', subCode: 'PermissionDenied' })
+        }
+      })
+    },
   })
 }

--- a/src/files/access.test.ts
+++ b/src/files/access.test.ts
@@ -1,0 +1,36 @@
+import { assert, assertObjectMatch } from '@std/assert'
+import { basename, dirname } from '@std/path'
+import { BIDSFileDeno } from './deno.ts'
+
+export function testAsyncFileAccess(
+  name: string,
+  fn: (file: BIDSFileDeno, ...args: any[]) => Promise<any>,
+  ...args: any[]
+) {
+  Deno.test(name, async (t) => {
+    await t.step('Dangling symlink', async () => {
+      const file = new BIDSFileDeno('tests/data', '/broken-symlink')
+      try {
+        await fn(file, ...args)
+        assert(false, 'Expected error')
+      } catch (e: any) {
+        assertObjectMatch(e, {
+          code: 'FILE_READ',
+          subCode: 'NotFound',
+          location: '/broken-symlink',
+        })
+      }
+    })
+    await t.step('Insufficient permissions', async () => {
+      const tmpfile = await Deno.makeTempFile()
+      await Deno.chmod(tmpfile, 0o000)
+      const file = new BIDSFileDeno('', tmpfile)
+      try {
+        await fn(file, ...args)
+        assert(false, 'Expected error')
+      } catch (e: any) {
+        assertObjectMatch(e, { code: 'FILE_READ', subCode: 'PermissionDenied' })
+      }
+    })
+  })
+}

--- a/src/files/access.test.ts
+++ b/src/files/access.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertObjectMatch } from '@std/assert'
+import { assert, assertArrayIncludes, assertObjectMatch } from '@std/assert'
 import { basename, dirname } from '@std/path'
 import { BIDSFileDeno } from './deno.ts'
 
@@ -16,9 +16,9 @@ export function testAsyncFileAccess(
       } catch (e: any) {
         assertObjectMatch(e, {
           code: 'FILE_READ',
-          subCode: 'NotFound',
           location: '/broken-symlink',
         })
+        assertArrayIncludes(['NotFound', 'FilesystemLoop'], [e.subCode])
       }
     })
     await t.step('Insufficient permissions', async () => {

--- a/src/files/access.ts
+++ b/src/files/access.ts
@@ -1,0 +1,35 @@
+import { type BIDSFile } from '../types/filetree.ts'
+import { type Issue } from '../types/issues.ts'
+
+function IOErrorToIssue(err: { code: string; name: string }): Issue {
+  const subcode = err.name
+  let issueMessage: string | undefined = undefined
+  if (err.code === 'ENOENT') {
+    issueMessage = 'Possible dangling symbolic link'
+  }
+  return { code: 'FILE_READ', subCode: err.name, issueMessage }
+}
+
+export function openStream(file: BIDSFile): ReadableStream<Uint8Array<ArrayBuffer>> {
+  try {
+    return file.stream
+  } catch (err: any) {
+    throw { location: file.path, ...IOErrorToIssue(err) }
+  }
+}
+
+export async function readBytes(
+  file: BIDSFile,
+  size: number,
+  offset = 0,
+): Promise<Uint8Array<ArrayBuffer>> {
+  return file.readBytes(size, offset).catch((err: any) => {
+    throw { location: file.path, ...IOErrorToIssue(err) }
+  })
+}
+
+export async function readText(file: BIDSFile): Promise<string> {
+  return file.text().catch((err: any) => {
+    throw { location: file.path, ...IOErrorToIssue(err) }
+  })
+}

--- a/src/files/access.ts
+++ b/src/files/access.ts
@@ -4,7 +4,7 @@ import { type Issue } from '../types/issues.ts'
 function IOErrorToIssue(err: { code: string; name: string }): Issue {
   const subcode = err.name
   let issueMessage: string | undefined = undefined
-  if (err.code === 'ENOENT') {
+  if (err.code === 'ENOENT' || err.code === 'ELOOP') {
     issueMessage = 'Possible dangling symbolic link'
   }
   return { code: 'FILE_READ', subCode: err.name, issueMessage }

--- a/src/files/gzip.test.ts
+++ b/src/files/gzip.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertObjectMatch } from '@std/assert'
 import { parseGzip } from './gzip.ts'
 import { BIDSFileDeno } from './deno.ts'
+import { testAsyncFileAccess } from './access.test.ts'
 
 Deno.test('parseGzip', async (t) => {
   await t.step('parses anonymized file', async () => {
@@ -40,3 +41,5 @@ Deno.test('parseGzip', async (t) => {
     assert(!gzip)
   })
 })
+
+testAsyncFileAccess('Test file access errors for parseGzip', parseGzip)

--- a/src/files/gzip.ts
+++ b/src/files/gzip.ts
@@ -4,6 +4,7 @@
  */
 import type { Gzip } from '@bids/schema/context'
 import type { BIDSFile } from '../types/filetree.ts'
+import { readBytes } from './access.ts'
 
 /**
  * Parse a gzip header from a file
@@ -19,7 +20,7 @@ export async function parseGzip(
   file: BIDSFile,
   maxBytes: number = 512,
 ): Promise<Gzip | undefined> {
-  const buf = await file.readBytes(maxBytes)
+  const buf = await readBytes(file, maxBytes)
   const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
   if (view.byteLength < 2 || view.getUint16(0, false) !== 0x1f8b) return undefined
 

--- a/src/files/json.test.ts
+++ b/src/files/json.test.ts
@@ -1,6 +1,7 @@
 import { type assert, assertObjectMatch } from '@std/assert'
 import type { BIDSFile } from '../types/filetree.ts'
 import type { FileIgnoreRules } from './ignore.ts'
+import { testAsyncFileAccess } from './access.test.ts'
 
 import { loadJSON } from './json.ts'
 
@@ -61,3 +62,5 @@ Deno.test('Test JSON error conditions', async (t) => {
     assertObjectMatch(error, { code: 'JSON_INVALID' })
   })
 })
+
+testAsyncFileAccess('Test file access errors for loadJSON', loadJSON)

--- a/src/files/json.ts
+++ b/src/files/json.ts
@@ -1,4 +1,5 @@
 import type { BIDSFile } from '../types/filetree.ts'
+import { readBytes } from './access.ts'
 
 async function readJSONText(file: BIDSFile): Promise<string> {
   // Read JSON text from a file
@@ -6,7 +7,7 @@ async function readJSONText(file: BIDSFile): Promise<string> {
   const decoder = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true })
   // Streaming TextDecoders are buggy in Deno and Chrome, so read the
   // entire file into memory before decoding and parsing
-  const data = await file.readBytes(file.size)
+  const data = await readBytes(file, file.size)
   try {
     const text = decoder.decode(data)
     if (text.startsWith('\uFEFF')) {

--- a/src/files/nifti.test.ts
+++ b/src/files/nifti.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertEquals, assertObjectMatch } from '@std/assert'
 import { FileIgnoreRules } from './ignore.ts'
 import { BIDSFileDeno } from './deno.ts'
+import { testAsyncFileAccess } from './access.test.ts'
 
 import { axisCodes, loadHeader } from './nifti.ts'
 
@@ -96,3 +97,5 @@ Deno.test('Test extracting axis codes', async (t) => {
     assertEquals(axisCodes(affine), ['A', 'S', 'R'])
   })
 })
+
+testAsyncFileAccess('Test file access errors for loadHeader', loadHeader)

--- a/src/files/nifti.ts
+++ b/src/files/nifti.ts
@@ -2,6 +2,7 @@ import { isCompressed, isNIFTI1, isNIFTI2, NIFTI1, NIFTI2 } from '@mango/nifti'
 import type { BIDSFile } from '../types/filetree.ts'
 import { logger } from '../utils/logger.ts'
 import type { NiftiHeader } from '@bids/schema/context'
+import { readBytes } from './access.ts'
 
 async function extract(buffer: Uint8Array, nbytes: number): Promise<Uint8Array<ArrayBuffer>> {
   // The fflate decompression that is used in nifti-reader does not like
@@ -32,8 +33,8 @@ async function extract(buffer: Uint8Array, nbytes: number): Promise<Uint8Array<A
 }
 
 export async function loadHeader(file: BIDSFile): Promise<NiftiHeader> {
+  const buf = await readBytes(file, 1024)
   try {
-    const buf = await file.readBytes(1024)
     const data = isCompressed(buf.buffer) ? await extract(buf, 540) : buf.slice(0, 540)
     let header
     if (isNIFTI1(data.buffer)) {

--- a/src/files/tiff.test.ts
+++ b/src/files/tiff.test.ts
@@ -1,6 +1,7 @@
 import { assert, assertObjectMatch } from '@std/assert'
 import { parseTIFF } from './tiff.ts'
 import { BIDSFileDeno } from './deno.ts'
+import { testAsyncFileAccess } from './access.test.ts'
 
 Deno.test('parseTIFF', async (t) => {
   await t.step('parse example file as TIFF', async () => {
@@ -53,3 +54,5 @@ Deno.test('parseTIFF', async (t) => {
     })
   })
 })
+
+testAsyncFileAccess('Test file access errors for parseTIFF', parseTIFF)

--- a/src/files/tiff.ts
+++ b/src/files/tiff.ts
@@ -5,6 +5,7 @@
 import type { Ome, Tiff } from '@bids/schema/context'
 import * as XML from '@libs/xml'
 import type { BIDSFile } from '../types/filetree.ts'
+import { readBytes } from './access.ts'
 
 function getImageDescription(
   dataview: DataView<ArrayBuffer>,
@@ -44,7 +45,7 @@ export async function parseTIFF(
   file: BIDSFile,
   OME: boolean,
 ): Promise<{ tiff?: Tiff; ome?: Ome }> {
-  const buf = await file.readBytes(4096)
+  const buf = await readBytes(file, 4096)
   const dataview = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)
   const magic = dataview.getUint16(0, true)
   const littleEndian = magic === 0x4949

--- a/src/files/tsv.test.ts
+++ b/src/files/tsv.test.ts
@@ -9,6 +9,7 @@ import { pathToFile } from './filetree.ts'
 import { loadTSV, loadTSVGZ } from './tsv.ts'
 import { streamFromString } from '../tests/utils.ts'
 import { ColumnsMap } from '../types/columns.ts'
+import { testAsyncFileAccess } from './access.test.ts'
 
 function compressedStreamFromString(str: string): ReadableStream<Uint8Array<ArrayBuffer>> {
   return streamFromString(str).pipeThrough(new CompressionStream('gzip')) as ReadableStream<
@@ -292,3 +293,5 @@ Deno.test('TSVGZ loading', async (t) => {
     assertEquals(map.c, ['3', '6', '9'])
   })
 })
+
+testAsyncFileAccess('Test file access errors for loadTSV', loadTSV)

--- a/src/files/tsv.ts
+++ b/src/files/tsv.ts
@@ -7,6 +7,7 @@ import { ColumnsMap } from '../types/columns.ts'
 import type { BIDSFile } from '../types/filetree.ts'
 import { filememoizeAsync } from '../utils/memoize.ts'
 import { createUTF8Stream } from './streams.ts'
+import { openStream } from './access.ts'
 
 async function loadColumns(
   reader: ReadableStreamDefaultReader<string>,
@@ -55,7 +56,7 @@ export async function loadTSVGZ(
   headers: string[],
   maxRows: number = -1,
 ): Promise<ColumnsMap> {
-  const reader = file.stream
+  const reader = openStream(file)
     .pipeThrough(new DecompressionStream('gzip'))
     .pipeThrough(createUTF8Stream())
     .pipeThrough(new TextLineStream())
@@ -75,7 +76,7 @@ export async function loadTSVGZ(
 }
 
 async function _loadTSV(file: BIDSFile, maxRows: number = -1): Promise<ColumnsMap> {
-  const reader = file.stream
+  const reader = openStream(file)
     .pipeThrough(createUTF8Stream())
     .pipeThrough(new TextLineStream())
     .getReader()

--- a/src/schema/associations.ts
+++ b/src/schema/associations.ts
@@ -9,6 +9,8 @@ import { walkBack } from '../files/inheritance.ts'
 import { evalCheck } from './applyRules.ts'
 import { expressionFunctions } from './expressionLanguage.ts'
 
+import { readText } from '../files/access.ts'
+
 function defaultAssociation(file: BIDSFile, _options: any): Promise<{ path: string }> {
   return Promise.resolve({ path: file.path })
 }
@@ -47,7 +49,7 @@ const associationLookup = {
     }
   },
   bval: async (file: BIDSFile, options: any): Promise<Bval> => {
-    const contents = await file.text()
+    const contents = await readText(file)
     const rows = parseBvalBvec(contents)
     return {
       path: file.path,
@@ -58,7 +60,7 @@ const associationLookup = {
     }
   },
   bvec: async (file: BIDSFile, options: any): Promise<Bvec> => {
-    const contents = await file.text()
+    const contents = await readText(file)
     const rows = parseBvalBvec(contents)
 
     if (rows.some((row) => row.length !== rows[0].length)) {

--- a/tests/data/broken-symlink
+++ b/tests/data/broken-symlink
@@ -1,0 +1,1 @@
+dangling-target


### PR DESCRIPTION
This PR creates `src/files/access.ts` that provides functional access to a bytestream, bytes and Unicode text. These wrap the properties and methods on `BIDSFile` and translate any IO errors into `FILE_READ` issues.

This seemed cleaner than injecting issue concepts into the `BIDSFile` model, and hopefully avoids complicating the process of adding a `BIDSFileRemote` or similar.

Closes #252