### PR TITLE
fix: properly encode JSON data in data URL for download link

### DIFF
--- a/changelog.d/20250916_102738_rosswilsonblair_data_url_encoding_issue_174.md
+++ b/changelog.d/20250916_102738_rosswilsonblair_data_url_encoding_issue_174.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- Fixed json encoding issue in web log download (Issue #174).
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -103,7 +103,7 @@ function App() {
           </ul>
           <Summary data={validation.summary} />
           <a
-            href={`data:application/json:${JSON.stringify(validation)}`}
+            href={`data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(validation))}`}
             target="_blank"
             download="bids-validator-output.json"
           >


### PR DESCRIPTION
- Add encodeURIComponent to JSON.stringify in data URL
- Include charset=utf-8 for proper character encoding
- Fixes issue #174 where special characters in JSON output caused broken download links