### PR TITLE
Add per context check to see if any files in its directory have the same name with different case

### DIFF
--- a/changelog.d/20250916_141028_rosswilsonblair_case_collision.md
+++ b/changelog.d/20250916_141028_rosswilsonblair_case_collision.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Added
+
+- Throw error on file name case collision.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -199,6 +199,11 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'warning',
     reason: 'The validation on this HED string returned a warning.',
   },
+  CASE_COLLISION: {
+    severity: 'error',
+    reason: 'Files with the same name but different casing have been found.',
+  },
+
 }
 
 export const nonSchemaIssues = { ...bidsIssues }

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -9,6 +9,7 @@ import { walkFileTree } from '../schema/walk.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 import type { Config, ValidatorOptions } from '../setup/options.ts'
 import { Summary } from '../summary/summary.ts'
+import { filenameCase } from './filenameCase.ts'
 import { filenameIdentify } from './filenameIdentify.ts'
 import { filenameValidate } from './filenameValidate.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
@@ -27,6 +28,7 @@ const perContextChecks: ContextCheckFunction[] = [
   emptyFile,
   filenameIdentify,
   filenameValidate,
+  filenameCase,
   applyRules,
   hedValidate,
 ]

--- a/src/validators/filenameCase.test.ts
+++ b/src/validators/filenameCase.test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from '@std/assert'
+import { filenameCase } from './filenameCase.ts'
+import { FileIgnoreRules } from '../files/ignore.ts'
+import { loadSchema } from '../setup/loadSchema.ts'
+import { pathsToTree } from '../files/filetree.ts'
+import { BIDSFileDeno } from '../files/deno.ts'
+import { BIDSContext, BIDSContextDataset } from '../schema/context.ts'
+import { walkFileTree } from '../schema/walk.ts'
+import { GenericSchema } from '../types/schema.ts'
+
+const schema = await loadSchema()
+const ignore = new FileIgnoreRules([])
+
+const filesToTest = [
+  '/file.txt',
+  '/File.txt',
+  '/FILE.txt',
+  '/file.TXT',
+  '/dir/file.txt',
+  '/different_file.txt'
+]
+
+const fileTree = pathsToTree(filesToTest)
+
+Deno.test('test filenameCase', async (t) => {
+  const dsContext = new BIDSContextDataset({ tree: fileTree, schema: schema })
+  for await (const context of walkFileTree(dsContext)) {
+    await filenameCase(schema as unknown as GenericSchema, context)
+  }
+  const issues = dsContext.issues.get({code: 'CASE_COLLISION'})
+  assertEquals(issues.length, 4)
+})

--- a/src/validators/filenameCase.ts
+++ b/src/validators/filenameCase.ts
@@ -1,8 +1,9 @@
 import type { ContextCheckFunction } from '../types/check.ts'
 
 export const filenameCase: ContextCheckFunction = (schema, context) => {
+    const lowercase = context.file.name.toLowerCase()
     const caseCollision = context.file.parent?.files.filter(otherFile => {
-      return (context.file.name.toLowerCase() === otherFile.name.toLowerCase() && context.file.name != otherFile.name)
+      return (otherFile != context.file && otherFile.name.toLowerCase() === lowercase)
     })
     if (caseCollision?.length) {
       context.dataset.issues.add({

--- a/src/validators/filenameCase.ts
+++ b/src/validators/filenameCase.ts
@@ -1,0 +1,15 @@
+import type { ContextCheckFunction } from '../types/check.ts'
+
+export const filenameCase: ContextCheckFunction = (schema, context) => {
+    const caseCollision = context.file.parent?.files.filter(otherFile => {
+      return (context.file.name.toLowerCase() === otherFile.name.toLowerCase() && context.file.name != otherFile.name)
+    })
+    if (caseCollision?.length) {
+      context.dataset.issues.add({
+        code: 'CASE_COLLISION',
+        location: context.path,
+        affects: caseCollision.map(file => file.path)
+      })
+    }
+  return Promise.resolve()
+}


### PR DESCRIPTION
This implementation uses toLowerCase, the other option would be localeCompare. Folk wisdom online being localeCompare is slower, but works better for more languages.

fixes #49