### PR TITLE
feat: Add issue message formatting

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -83,7 +83,7 @@ jobs:
             touch tests/data/bids-examples/${DS}/.SKIP_VALIDATION
           done
         if: github.ref_name != 'dev' && github.base_ref != 'dev'
-      - run: deno test --node-modules-dir=auto $PERMS --coverage=cov/ src/
+      - run: deno test --parallel --node-modules-dir=auto $PERMS --coverage=cov/ src/
       - name: Collect coverage
         run: deno coverage cov/ --lcov --output=coverage.lcov
         if: ${{ always() }}

--- a/changelog.d/20250917_113053_markiewicz_message_interpolation.md
+++ b/changelog.d/20250917_113053_markiewicz_message_interpolation.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+### Added
+
+- Support issues messages that access validation context variables.
+
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -1,7 +1,7 @@
 import type { GenericRule, GenericSchema, SchemaFields, SchemaTypeLike } from '../types/schema.ts'
 import type { Severity } from '../types/issues.ts'
 import type { BIDSContext } from './context.ts'
-import { contextFunction, prepareContext } from './expressionLanguage.ts'
+import { contextFunction, formatter, prepareContext } from './expressionLanguage.ts'
 import { logger } from '../utils/logger.ts'
 import { compile } from '../validators/json.ts'
 import type { DefinedError } from '@ajv'
@@ -166,12 +166,13 @@ function _evalRuleChecks(
 ): boolean {
   if (rule.checks && !mapEvalCheck(rule.checks, context)) {
     if (rule.issue?.code && rule.issue?.message) {
+      const format = formatter(rule.issue.message)
       context.dataset.issues.add({
         code: rule.issue.code,
         location: context.path,
         rule: schemaPath,
         severity: rule.issue.level as Severity,
-      }, rule.issue.message)
+      }, format(context))
     } else {
       context.dataset.issues.add(
         { code: 'CHECK_ERROR', location: context.path, rule: schemaPath },

--- a/src/schema/expressionLanguage.ts
+++ b/src/schema/expressionLanguage.ts
@@ -140,6 +140,24 @@ function _contextFunction(expr: string): (context: BIDSContext) => any {
  */
 export const contextFunction = memoize(_contextFunction)
 
+function _formatter(format: string): (context: BIDSContext) => string {
+  if (!format.includes('{')) {
+    return (context: BIDSContext) => format
+  }
+  const template = format.replace(/{/g, '${').replace(/\\/g, '\\\\').replace(/`/g, '\\`')
+  return new Function('context', `with (context) { return \`${template}\` }`) as (
+    context: BIDSContext,
+  ) => string
+}
+
+/**
+ * Generate a function that formats a string using the BIDS context.
+ *
+ * Strings are expected to use Python-style formatting,
+ * e.g., "sub-{entities.sub}/ses-{entities.ses}".
+ */
+export const formatter = memoize(_formatter)
+
 function safeContext(context: BIDSContext): BIDSContext {
   return new Proxy(context, {
     has: () => true,

--- a/src/schema/expressionLanguage.ts
+++ b/src/schema/expressionLanguage.ts
@@ -92,7 +92,7 @@ export const expressionFunctions = {
   },
   unique: <T>(list: T[]): T[] | null => {
     if (list !== null) {
-        return [...new Set(list)]
+      return [...new Set(list)]
     }
     return null
   },

--- a/src/schema/expressionLanguage.ts
+++ b/src/schema/expressionLanguage.ts
@@ -1,4 +1,5 @@
 import type { BIDSContext } from './context.ts'
+import { memoize } from '../utils/memoize.ts'
 
 function exists(this: BIDSContext, list: string[], rule: string = 'dataset'): number {
   if (list == null) {
@@ -123,4 +124,32 @@ export const expressionFunctions = {
   allequal: <T>(a: T[], b: T[]): boolean => {
     return (a != null && b != null) && a.length === b.length && a.every((v, i) => v === b[i])
   },
+}
+
+/**
+ * Generate a function that evaluates an expression using the BIDS context.
+ */
+function _contextFunction(expr: string): (context: BIDSContext) => any {
+  return new Function('context', `with (context) { return ${expr.replace(/\\/g, '\\\\')} }`) as (
+    context: BIDSContext,
+  ) => any
+}
+
+/**
+ * Generate a function that evaluates an expression using the BIDS context.
+ */
+export const contextFunction = memoize(_contextFunction)
+
+function safeContext(context: BIDSContext): BIDSContext {
+  return new Proxy(context, {
+    has: () => true,
+    get: (target: any, prop: any) => prop === Symbol.unscopables ? undefined : target[prop],
+  })
+}
+
+export function prepareContext(context: BIDSContext): BIDSContext {
+  Object.assign(context, expressionFunctions)
+  // @ts-expect-error
+  context.exists.bind(context)
+  return safeContext(context)
 }


### PR DESCRIPTION
This PR adds issue message formatting, to allow for schema issue messages that reference context variables to provide more useful messages.

This builds on the expression evaluation utility to achieve a limited subset of Python's `str.format` functionality. The conversion is very simple: `{` becomes `${`, backslashes are escaped, and finally backticks are escaped so that we can use Javascript's interpolation strings.

While doing this, it seemed cleanest to move encapsulation into `expressionLanguage.ts`, and prepare the context (by setting the expression language functions and wrapping in a `Proxy`) just once in each exported function for `applyRules.ts`. Internally, `applyRules.ts` assumes that it has a prepared context object.