### PR TITLE
Throw an error, do not just log an error, if provided schema is not legit

### DIFF
--- a/changelog.d/20250918_173356_yarikoptic_enh_crash.md
+++ b/changelog.d/20250918_173356_yarikoptic_enh_crash.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Throw an error if specified schema (e.g. via `--schema` or `BIDS_SCHEMA` env
+  var) could not be loaded.

--- a/src/setup/loadSchema.ts
+++ b/src/setup/loadSchema.ts
@@ -6,7 +6,6 @@ import { setCustomMetadataFormats } from '../validators/json.ts'
 /**
  * Load the schema from the specification
  *
- * version is ignored when the network cannot be accessed
  */
 export async function loadSchema(version?: string): Promise<Schema> {
   let schemaUrl = version
@@ -31,10 +30,10 @@ export async function loadSchema(version?: string): Promise<Schema> {
         objectPathHandler,
       ) as Schema
     } catch (error) {
-      // No network access or other errors
+      // If a custom schema URL was explicitly provided, fail rather than falling back
       console.error(error)
-      console.error(
-        `Warning, could not load schema from ${schemaUrl}, falling back to internal version`,
+      throw new Error(
+        `Failed to load schema from ${schemaUrl}: ${error instanceof Error ? error.message : String(error)}`,
       )
     }
   }


### PR DESCRIPTION
I think current behavior violates the principle of the least surprise: I ran validation while providing custom schema source, it executed with many warnings and errors reported to the screen. It is only after scrolling far up, I saw that actually my specification was wrong and operation resorted to built-in schema.

Moreover, having varying results depending on network flukes is also not a good behavior.

TODOs (if agreed in principle)
- [x] add changelog
- [ ] fix or add a test (there should be a test for such behavior) 