### PR TITLE
fix: Include target entities in exact match check

### DIFF
--- a/src/files/inheritance.test.ts
+++ b/src/files/inheritance.test.ts
@@ -72,4 +72,22 @@ Deno.test('walkback inheritance tests', async (t) => {
       assertEquals(rootElectrodes.path, '/space-talairach_electrodes.tsv')
     },
   )
+  await t.step(
+    'The presence of target entities does not trigger exact match logic',
+    async () => {
+      const rootFileTree = pathsToTree([
+        '/sub-01/ieeg/sub-01_task-rest_ieeg.edf',
+        '/sub-01/ieeg/sub-01_task-rest_space-anat_electrodes.tsv',
+        '/sub-01/ieeg/sub-01_task-rest_space-MNI_electrodes.tsv',
+      ])
+      const dataFile = rootFileTree.get('sub-01/ieeg/sub-01_task-rest_ieeg.edf') as BIDSFile
+      const electrodes = walkBack(dataFile, true, ['.tsv'], 'electrodes', ['space'])
+      const localElectrodes: BIDSFile[] = electrodes.next().value
+      assert(Array.isArray(localElectrodes))
+      assertEquals(localElectrodes.map((f) => f.path), [
+        '/sub-01/ieeg/sub-01_task-rest_space-anat_electrodes.tsv',
+        '/sub-01/ieeg/sub-01_task-rest_space-MNI_electrodes.tsv',
+      ])
+    },
+  )
 })

--- a/src/files/inheritance.ts
+++ b/src/files/inheritance.ts
@@ -50,7 +50,7 @@ export function* walkBack<T extends string[]>(
     if (candidates.length > 1) {
       const exactMatch = candidates.find((file) => {
         const { entities } = readEntities(file.name)
-        return Object.keys(sourceParts.entities).every((entity) =>
+        return [...Object.keys(sourceParts.entities), ...(targetEntities ?? [])].every((entity) =>
           entities[entity] === sourceParts.entities[entity]
         )
       })


### PR DESCRIPTION
Pulled out of #268 and tested. This is an independent bug that just hasn't mattered before.