### PR TITLE
fix: Weakly reference parent FileTrees, upgrade hed-validator

### DIFF
--- a/changelog.d/20251003_131902_markiewicz_weakref_parents.md
+++ b/changelog.d/20251003_131902_markiewicz_weakref_parents.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Circular references that could lead to a hanging process were mitigated. [#278]
+
+[#278]: https://github.com/bids-standard/bids-validator/issues/278

--- a/deno.json
+++ b/deno.json
@@ -31,7 +31,7 @@
     "@bids/schema": "jsr:@bids/schema@~1.1.0",
     "@cliffy/command": "jsr:@effigies/cliffy-command@1.0.0-dev.8",
     "@cliffy/table": "jsr:@effigies/cliffy-table@1.0.0-dev.5",
-    "@hed/validator": "npm:hed-validator@~4.0.1",
+    "@hed/validator": "npm:hed-validator@~4.1.4",
     "@ignore": "npm:ignore@^7.0.5",
     "@libs/xml": "jsr:@libs/xml@^6.0.8",
     "@mango/nifti": "npm:@bids/nifti-reader-js@^0.6.9",

--- a/deno.lock
+++ b/deno.lock
@@ -41,7 +41,7 @@
     "npm:@bids/nifti-reader-js@~0.6.9": "0.6.9",
     "npm:@types/node@*": "22.15.15",
     "npm:ajv@^8.17.1": "8.17.1",
-    "npm:hed-validator@~4.0.1": "4.0.1",
+    "npm:hed-validator@~4.1.4": "4.1.4",
     "npm:ignore@^7.0.5": "7.0.5"
   },
   "jsr": {
@@ -224,34 +224,9 @@
         "require-from-string"
       ]
     },
-    "base64-js@1.5.1": {
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "buffer@6.0.3": {
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dependencies": [
-        "base64-js",
-        "ieee754"
-      ]
-    },
     "core-js-pure@3.45.1": {
       "integrity": "sha512-OHnWFKgTUshEU8MK+lOs1H8kC8GkTi9Z1tvNkxrCcw9wl3MJIO7q2ld77wjWn4/xuGrVu2X+nME1iIIPBSdyEQ==",
       "scripts": true
-    },
-    "cross-fetch@4.1.0": {
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "dependencies": [
-        "node-fetch"
-      ]
-    },
-    "date-and-time@3.6.0": {
-      "integrity": "sha512-V99gLaMqNQxPCObBumb31Bfy3OByXnpqUM0yHPi/aBQE61g42A2rGk6Z2CDnpLrWsOFLQwOgl4Vgshw6D44ebw=="
-    },
-    "date-fns@4.1.0": {
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
-    },
-    "events@3.3.0": {
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
@@ -259,35 +234,29 @@
     "fast-uri@3.0.6": {
       "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="
     },
+    "fast-xml-parser@5.2.5": {
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "dependencies": [
+        "strnum"
+      ],
+      "bin": true
+    },
     "fflate@0.8.2": {
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
     },
-    "hed-validator@4.0.1": {
-      "integrity": "sha512-JISoDcsm3IjK3l5+sbAd9DBOno9TWyk2EC2kXAaX5JLo9RIZH3e/sWgI7spMxR60VOT69/CCo/YD3ak3/AhkCw==",
+    "hed-validator@4.1.4": {
+      "integrity": "sha512-Cyprv/TCXUP1FC5c/h1Yi3k2XawlDP1YJ5kxI724WSRg67Xz/RlYnMxJposhAIZMFPWMdDkATtoM5fro68k7RA==",
       "dependencies": [
-        "buffer",
         "core-js-pure",
-        "cross-fetch",
-        "date-and-time",
-        "date-fns",
-        "events",
+        "fast-xml-parser",
         "lodash",
-        "path",
         "pluralize",
         "semver",
-        "string_decoder",
-        "unicode-name",
-        "xml2js"
+        "unicode-name"
       ]
-    },
-    "ieee754@1.2.1": {
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore@7.0.5": {
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="
-    },
-    "inherits@2.0.3": {
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "json-schema-traverse@1.0.0": {
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
@@ -295,78 +264,24 @@
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node-fetch@2.7.0": {
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": [
-        "whatwg-url"
-      ]
-    },
-    "path@0.12.7": {
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "dependencies": [
-        "process",
-        "util"
-      ]
-    },
     "pluralize@8.0.0": {
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
-    "process@0.11.10": {
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-    },
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-    },
-    "safe-buffer@5.2.1": {
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "sax@1.4.1": {
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "semver@7.7.2": {
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "bin": true
     },
-    "string_decoder@1.3.0": {
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": [
-        "safe-buffer"
-      ]
-    },
-    "tr46@0.0.3": {
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    "strnum@2.1.1": {
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="
     },
     "undici-types@6.21.0": {
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
-    "unicode-name@1.0.4": {
-      "integrity": "sha512-Y8KWGWHyZo5MVHsdjSFIshZesmQbLkh0l7RAv4uFNgVMjBIaCWVZAzch5b9jKaMHDnhroebDoM79/lLpzBLKvQ=="
-    },
-    "util@0.10.4": {
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dependencies": [
-        "inherits"
-      ]
-    },
-    "webidl-conversions@3.0.1": {
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url@5.0.0": {
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": [
-        "tr46",
-        "webidl-conversions"
-      ]
-    },
-    "xml2js@0.6.2": {
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "dependencies": [
-        "sax",
-        "xmlbuilder"
-      ]
-    },
-    "xmlbuilder@11.0.1": {
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    "unicode-name@1.1.0": {
+      "integrity": "sha512-2XBI32vZP6a1tJmMDSUBabiIZuY+1udwZUoS7i5BTSU2c4ELMy6YJrTPF9uvYOVMU4vTMlHH6HG/TsHjCEsazA=="
     }
   },
   "remote": {
@@ -472,7 +387,7 @@
       "jsr:@std/yaml@^1.0.9",
       "npm:@bids/nifti-reader-js@~0.6.9",
       "npm:ajv@^8.17.1",
-      "npm:hed-validator@~4.0.1",
+      "npm:hed-validator@~4.1.4",
       "npm:ignore@^7.0.5"
     ]
   }

--- a/src/files/browser.ts
+++ b/src/files/browser.ts
@@ -12,7 +12,7 @@ export class BIDSFileBrowser implements BIDSFile {
   #file: File
   name: string
   path: string
-  parent: FileTree
+  #parent!: WeakRef<FileTree>
   viewed: boolean = false
 
   constructor(file: File, ignore: FileIgnoreRules, parent?: FileTree) {
@@ -23,6 +23,14 @@ export class BIDSFileBrowser implements BIDSFile {
     const prefixLength = relativePath.indexOf('/')
     this.path = relativePath.substring(prefixLength)
     this.parent = parent ?? new FileTree('', '/', undefined)
+  }
+
+  get parent(): FileTree {
+    return this.#parent.deref() as FileTree
+  }
+
+  set parent(tree: FileTree) {
+    this.#parent = new WeakRef(tree)
   }
 
   get size(): number {

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -17,7 +17,7 @@ export class BIDSFileDeno implements BIDSFile {
   #ignore: FileIgnoreRules
   name: string
   path: string
-  parent: FileTree
+  #parent!: WeakRef<FileTree>
   #fileInfo?: Deno.FileInfo
   #datasetAbsPath: string
   viewed: boolean = false
@@ -39,6 +39,14 @@ export class BIDSFileDeno implements BIDSFile {
 
   private _getPath(): string {
     return join(this.#datasetAbsPath, this.path)
+  }
+
+  get parent(): FileTree {
+    return this.#parent.deref() as FileTree
+  }
+
+  set parent(tree: FileTree) {
+    this.#parent = new WeakRef(tree)
   }
 
   get size(): number {

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -32,7 +32,7 @@ export class FileTree {
   files: BIDSFile[]
   directories: FileTree[]
   viewed: boolean
-  parent?: FileTree
+  #parent?: WeakRef<FileTree>
   #ignore: FileIgnoreRules
 
   constructor(path: string, name: string, parent?: FileTree, ignore?: FileIgnoreRules) {
@@ -43,6 +43,14 @@ export class FileTree {
     this.parent = parent
     this.viewed = false
     this.#ignore = ignore ?? new FileIgnoreRules([])
+  }
+
+  get parent(): FileTree | undefined {
+    return this.#parent?.deref()
+  }
+
+  set parent(tree: FileTree | undefined) {
+    this.#parent = tree ? new WeakRef(tree) : undefined
   }
 
   get ignored(): boolean {


### PR DESCRIPTION
I've confirmed that this no longer hangs:

```console
$ deno run -A src/bids-validator.ts --ignoreWarnings tests/data/bids-examples/synthetic
```

Closes #278.