### PR TITLE
feat: Start loading contexts earlier, buffer contexts for better concurrency

### DIFF
--- a/changelog.d/20251014_150638_markiewicz_context_queue.md
+++ b/changelog.d/20251014_150638_markiewicz_context_queue.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Validation context generation was tweaked to improve concurrency, giving 4x validation
+  speedups in some cases.

--- a/src/schema/context.test.ts
+++ b/src/schema/context.test.ts
@@ -1,11 +1,24 @@
 import { assert, assertEquals, assertObjectMatch } from '@std/assert'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
+import type { BIDSFile } from '../types/filetree.ts'
+import type { FileTree } from '../types/filetree.ts'
+import type { BIDSContextDataset } from './context.ts'
 import { BIDSContext } from './context.ts'
 import { dataFile, rootFileTree } from './fixtures.test.ts'
 
+/* Async helper to create a loaded BIDSContext */
+export async function makeBIDSContext(
+  file: BIDSFile,
+  dsContext?: BIDSContextDataset,
+  fileTree?: FileTree,
+): Promise<BIDSContext> {
+  const context = new BIDSContext(file, dsContext, fileTree)
+  await context.loaded
+  return context
+}
+
 Deno.test('test context LoadSidecar', async (t) => {
-  const context = new BIDSContext(dataFile)
-  await context.loadSidecar()
+  const context = await makeBIDSContext(dataFile)
   await t.step('sidecar overwrites correct fields', () => {
     const { rootOverwrite, subOverwrite } = context.sidecar
     assertObjectMatch(context.sidecar, {
@@ -30,8 +43,7 @@ Deno.test('test context LoadSidecar', async (t) => {
 })
 
 Deno.test('test context loadSubjects', async (t) => {
-  const context = new BIDSContext(dataFile, undefined, rootFileTree)
-  await context.loadSubjects()
+  const context = await makeBIDSContext(dataFile, undefined, rootFileTree)
   await t.step('context produces correct subjects object', () => {
     assert(context.dataset.subjects, 'subjects object exists')
     assert(context.dataset.subjects.sub_dirs.length == 1, 'there is only one sub dir found')

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -142,6 +142,7 @@ export class BIDSContext implements Context {
   file: BIDSFile
   filenameRules: string[]
   sidecarKeyOrigin: Record<string, string>
+  loaded: Promise<void>
 
   constructor(
     file: BIDSFile,
@@ -167,6 +168,7 @@ export class BIDSContext implements Context {
     this.columns = new ColumnsMap() as Record<string, string[]>
     this.json = {}
     this.associations = {} as Associations
+    this.loaded = this.asyncLoads()
   }
 
   get schema(): Schema {

--- a/src/schema/expressionLanguage.test.ts
+++ b/src/schema/expressionLanguage.test.ts
@@ -6,11 +6,12 @@ import {
   prepareContext,
 } from './expressionLanguage.ts'
 import { dataFile, rootFileTree } from './fixtures.test.ts'
-import { BIDSContext } from './context.ts'
+import type { BIDSContext } from './context.ts'
+import { makeBIDSContext } from './context.test.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
 
 Deno.test('test expression functions', async (t) => {
-  const context = new BIDSContext(dataFile, undefined, rootFileTree)
+  const context = await makeBIDSContext(dataFile, undefined, rootFileTree)
 
   await t.step('index function', () => {
     const index = expressionFunctions.index

--- a/src/tests/local/hed-integration.test.ts
+++ b/src/tests/local/hed-integration.test.ts
@@ -3,7 +3,8 @@ import { assert, assertEquals } from '@std/assert'
 import { readFileTree } from '../../files/deno.ts'
 import type { DatasetIssues } from '../../issues/datasetIssues.ts'
 import { loadSchema } from '../../setup/loadSchema.ts'
-import { BIDSContext, BIDSContextDataset } from '../../schema/context.ts'
+import { BIDSContextDataset } from '../../schema/context.ts'
+import { makeBIDSContext } from '../../schema/context.test.ts'
 import { BIDSFile, FileTree } from '../../types/filetree.ts'
 import type { GenericSchema } from '../../types/schema.ts'
 import { hedValidate } from '../../validators/hed.ts'
@@ -21,8 +22,7 @@ Deno.test('hed-validator not triggered', async (t) => {
     const eventFile = tree.get('sub-01/func/sub-01_task-rhymejudgment_events.tsv')
     assert(eventFile !== undefined)
     assert(eventFile instanceof BIDSFile)
-    const context = new BIDSContext(eventFile, dsContext)
-    await context.asyncLoads()
+    const context = await makeBIDSContext(eventFile, dsContext)
     await hedValidate(schema as unknown as GenericSchema, context)
     assert(context.dataset.issues.size === 0)
   })
@@ -41,8 +41,7 @@ Deno.test('hed-validator fails with bad schema version', async (t) => {
     const eventFile = tree.get('sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv')
     assert(eventFile !== undefined)
     assert(eventFile instanceof BIDSFile)
-    const context = new BIDSContext(eventFile, dsContext)
-    await context.asyncLoads()
+    const context = await makeBIDSContext(eventFile, dsContext)
     await hedValidate(schema as unknown as GenericSchema, context)
     assertEquals(context.dataset.issues.size, 1)
     assertEquals(context.dataset.issues.get({ code: 'HED_ERROR' }).length, 1)

--- a/src/utils/queue.ts
+++ b/src/utils/queue.ts
@@ -1,0 +1,43 @@
+export async function* bufferAsyncIterator<T>(
+  asyncIterator: AsyncIterable<T>,
+  bufferSize: number = 5,
+): AsyncGenerator<T, void, undefined> {
+  const iterator = asyncIterator[Symbol.asyncIterator]()
+  const promises: Promise<IteratorResult<T>>[] = []
+
+  // Initialize buffer
+  for (let i = 0; i < bufferSize; i++) {
+    promises.push(iterator.next())
+  }
+
+  while (promises.length > 0) {
+    const result = await promises.shift()!
+
+    if (!result.done) {
+      yield result.value
+      // Keep buffer full
+      promises.push(iterator.next())
+    }
+  }
+}
+
+type CleanupFunction = () => void
+
+export async function* cleanupAsyncIterator<T extends object>(
+  asyncIterator: AsyncIterable<T | CleanupFunction>,
+): AsyncGenerator<T, void, undefined> {
+  for await (const item of asyncIterator) {
+    if (typeof item === 'function') {
+      item()
+    } else {
+      yield item
+    }
+  }
+}
+
+export async function* queuedAsyncIterator<T extends object>(
+  asyncIterator: AsyncIterable<T | CleanupFunction>,
+  bufferSize: number = 5,
+): AsyncGenerator<T, void, undefined> {
+  yield* cleanupAsyncIterator(bufferAsyncIterator(asyncIterator, bufferSize))
+}

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -108,7 +108,7 @@ export async function validate(
     return false
   })
 
-  for await (const context of walkFileTree(dsContext)) {
+  for await (const context of walkFileTree(dsContext, 20)) {
     // TODO - Skip ignored files for now (some tests may reference ignored files)
     if (context.file.ignored) {
       continue

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -109,17 +109,12 @@ export async function validate(
   })
 
   for await (const context of walkFileTree(dsContext, 20)) {
-    // TODO - Skip ignored files for now (some tests may reference ignored files)
-    if (context.file.ignored) {
-      continue
-    }
     if (
       dsContext.dataset_description.DatasetType == 'raw' &&
       context.file.path.includes('derivatives')
     ) {
       continue
     }
-    await context.loaded
     // Run majority of checks
     for (const check of perContextChecks) {
       await check(schema as unknown as GenericSchema, context)

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -119,7 +119,7 @@ export async function validate(
     ) {
       continue
     }
-    await context.asyncLoads()
+    await context.loaded
     // Run majority of checks
     for (const check of perContextChecks) {
       await check(schema as unknown as GenericSchema, context)

--- a/src/validators/filenameIdentify.test.ts
+++ b/src/validators/filenameIdentify.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from '@std/assert'
 import { SEPARATOR_PATTERN } from '@std/path'
-import { BIDSContext } from '../schema/context.ts'
+import { makeBIDSContext } from '../schema/context.test.ts'
 import { _findRuleMatches, findDirRuleMatches, hasMatch } from './filenameIdentify.ts'
 import { BIDSFileDeno } from '../files/deno.ts'
 import { FileIgnoreRules } from '../files/ignore.ts'
@@ -27,7 +27,7 @@ Deno.test('test _findRuleMatches', async (t) => {
   await t.step('Rule stem matches', async () => {
     const fileName = 'participants.json'
     const file = new BIDSFileDeno(PATH, fileName, ignore)
-    const context = new BIDSContext(file)
+    const context = await makeBIDSContext(file)
     _findRuleMatches(node, schemaPath, context)
     assertEquals(context.filenameRules[0], schemaPath)
   })
@@ -38,7 +38,7 @@ Deno.test('test _findRuleMatches', async (t) => {
     async () => {
       const fileName = 'task-rest_bold.json'
       const file = new BIDSFileDeno(PATH, fileName, ignore)
-      const context = new BIDSContext(file)
+      const context = await makeBIDSContext(file)
       _findRuleMatches(recurseNode, schemaPath, context)
       assertEquals(context.filenameRules[0], `${schemaPath}.recurse`)
     },
@@ -49,7 +49,7 @@ Deno.test('test hasMatch', async (t) => {
   await t.step('hasMatch', async () => {
     const fileName = '/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_bold.nii'
     const file = new BIDSFileDeno(PATH, fileName, ignore)
-    const context = new BIDSContext(file)
+    const context = await makeBIDSContext(file)
     hasMatch(schema, context)
   })
 
@@ -58,7 +58,7 @@ Deno.test('test hasMatch', async (t) => {
     const [dir, base] = tmpFile.split(SEPARATOR_PATTERN)
     const file = new BIDSFileDeno(dir, `/${base}`, ignore)
 
-    const context = new BIDSContext(file)
+    const context = await makeBIDSContext(file)
     await hasMatch(schema, context)
     assertEquals(
       context.dataset.issues.get({
@@ -73,7 +73,7 @@ Deno.test('test hasMatch', async (t) => {
     const path = `${PATH}/../bids-examples/fnirs_automaticity`
     const fileName = 'events.json'
     const file = new BIDSFileDeno(path, fileName, ignore)
-    const context = new BIDSContext(file)
+    const context = await makeBIDSContext(file)
     context.filenameRules = [
       'rules.files.raw.events.events__mri',
       'rules.files.raw.events.events__pet',
@@ -87,7 +87,7 @@ Deno.test('test directoryIdentify', async (t) => {
   await t.step('Test entity based rule', async () => {
     const fileName = '/sub-01/'
     const file = new BIDSFileDeno(PATH, fileName, ignore)
-    const context = new BIDSContext(file)
+    const context = await makeBIDSContext(file)
     context.directory = true
     await findDirRuleMatches(schema, context)
     assertEquals(context.filenameRules.length, 1)
@@ -96,7 +96,7 @@ Deno.test('test directoryIdentify', async (t) => {
   await t.step('Test name based rule', async () => {
     const fileName = '/derivatives/'
     const file = new BIDSFileDeno(PATH, fileName, ignore)
-    const context = new BIDSContext(file)
+    const context = await makeBIDSContext(file)
     context.directory = true
     await findDirRuleMatches(schema, context)
     assertEquals(context.filenameRules.length, 1)
@@ -105,7 +105,7 @@ Deno.test('test directoryIdentify', async (t) => {
   await t.step('Test value based rule', async () => {
     const fileName = '/func/'
     const file = new BIDSFileDeno(`${PATH}/sub-01/ses-01`, fileName, ignore)
-    const context = new BIDSContext(file)
+    const context = await makeBIDSContext(file)
     context.directory = true
     await findDirRuleMatches(schema, context)
     assertEquals(context.filenameRules.length, 1)

--- a/src/validators/filenameValidate.test.ts
+++ b/src/validators/filenameValidate.test.ts
@@ -1,7 +1,7 @@
 import type { FileTree } from '../types/filetree.ts'
 import type { GenericSchema } from '../types/schema.ts'
 import { assertEquals } from '@std/assert'
-import { BIDSContext } from '../schema/context.ts'
+import { makeBIDSContext } from '../schema/context.test.ts'
 import { type atRoot, type entityLabelCheck, missingLabel } from './filenameValidate.ts'
 import type { BIDSFileDeno } from '../files/deno.ts'
 import { pathToFile } from '../files/filetree.test.ts'
@@ -12,7 +12,7 @@ const schema = (await loadSchema()) as unknown as GenericSchema
 
 Deno.test('test missingLabel', async (t) => {
   await t.step('File with underscore and no hyphens errors out.', async () => {
-    const context = new BIDSContext(pathToFile('/no_label_entities.wav'))
+    const context = await makeBIDSContext(pathToFile('/no_label_entities.wav'))
     // Need some suffix rule to trigger the check,
     // otherwise this is trigger-happy.
     context.filenameRules = ['rules.files.raw.dwi.dwi']
@@ -31,7 +31,7 @@ Deno.test('test missingLabel', async (t) => {
   await t.step(
     "File with underscores and hyphens doesn't error out.",
     async () => {
-      const context = new BIDSContext(pathToFile('/we-do_have-some_entities.wav'))
+      const context = await makeBIDSContext(pathToFile('/we-do_have-some_entities.wav'))
       // Doesn't really matter that the rule doesn't apply
       context.filenameRules = ['rules.files.raw.dwi.dwi']
 

--- a/src/validators/validateFiles.test.ts
+++ b/src/validators/validateFiles.test.ts
@@ -2,6 +2,7 @@ import { assert, assertEquals } from '@std/assert'
 import { filenameIdentify } from './filenameIdentify.ts'
 import { filenameValidate } from './filenameValidate.ts'
 import { BIDSContext, BIDSContextDataset } from '../schema/context.ts'
+import { makeBIDSContext } from '../schema/context.test.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
 import type { GenericSchema, Schema } from '../types/schema.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
@@ -11,12 +12,12 @@ import { StringOpener } from '../files/openers.test.ts'
 
 const schema = await loadSchema()
 
-function makeContext(path: string, contents: string = ''): BIDSContext {
+async function makeContext(path: string, contents: string = ''): Promise<BIDSContext> {
   const tree = pathsToTree([path])
   const dataset = new BIDSContextDataset({ schema, tree })
   const file = tree.get(path) as BIDSFile
   file.opener = new StringOpener(contents)
-  return new BIDSContext(file, dataset)
+  return makeBIDSContext(file, dataset)
 }
 
 Deno.test('test valid paths', async (t) => {
@@ -57,7 +58,7 @@ Deno.test('test valid paths', async (t) => {
   ]
   for (const filename of validFiles) {
     await t.step(filename, async () => {
-      const context = makeContext(filename)
+      const context = await makeContext(filename, '{"valid": "json"}')
       await filenameIdentify(schema, context)
       await filenameValidate(schema as unknown as GenericSchema, context)
       assertEquals(
@@ -116,7 +117,7 @@ Deno.test('test invalid paths', async (t) => {
   ]
   for (const filename of invalidFiles) {
     await t.step(filename, async () => {
-      const context = makeContext(filename)
+      const context = await makeContext(filename)
       await filenameIdentify(schema, context)
       await filenameValidate(schema as unknown as GenericSchema, context)
       assert(


### PR DESCRIPTION
This PR has two pieces, neither of which produce any noticeable speedup on their own. The first creates a `context.loaded` Promise that indicates whether the context is fully loaded. The second creates a queue that can hold onto initializing contexts until we're ready for them.

For ds000001, I was getting about 9s per run. With a queue of 5, down to 4s, and a queue of 20 got us down to 2s.