### PR TITLE
test: Add opener implementations for tests

### DIFF
--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -2,18 +2,11 @@ import { assert, assertEquals } from '@std/assert'
 import { FileIgnoreRules } from './ignore.ts'
 import { BIDSFile, type FileOpener, type FileTree } from '../types/filetree.ts'
 import { filesToTree } from './filetree.ts'
-import { asyncStreamFromString } from '../tests/utils.ts'
-
-class NullFileOpener implements FileOpener {
-  size = 0
-  stream = () => asyncStreamFromString('')
-  text = () => Promise.resolve('')
-  readBytes = async (size: number, offset?: number) => new Uint8Array()
-}
+import { StringOpener } from './openers.test.ts'
 
 export function pathToFile(path: string, ignored: boolean = false): BIDSFile {
   const name = path.split('/').pop() as string
-  return new BIDSFile(path, new NullFileOpener(), ignored)
+  return new BIDSFile(path, new StringOpener(''), ignored)
 }
 
 export function pathsToTree(paths: string[], ignore?: string[]): FileTree {

--- a/src/files/openers.test.ts
+++ b/src/files/openers.test.ts
@@ -1,0 +1,154 @@
+/**
+ * File openers for use in testing
+ */
+import { assertEquals } from '@std/assert'
+import { type FileOpener } from '../types/filetree.ts'
+import { streamFromString } from '../tests/utils.ts'
+import { createUTF8Stream } from './streams.ts'
+
+const textEncoder = new TextEncoder()
+const textDecoder = new TextDecoder()
+
+export class BytesOpener implements FileOpener {
+  contents: Uint8Array<ArrayBuffer>
+  size: number
+
+  constructor(contents: Uint8Array<ArrayBuffer>) {
+    this.contents = contents
+    this.size = contents.length
+  }
+
+  async text(): Promise<string> {
+    return textDecoder.decode(this.contents)
+  }
+
+  async readBytes(size: number, offset = 0): Promise<Uint8Array<ArrayBuffer>> {
+    return this.contents.slice(offset, offset + size)
+  }
+
+  async stream(): Promise<ReadableStream<Uint8Array<ArrayBuffer>>> {
+    const contents = this.contents
+    return new ReadableStream({
+      start(controller) {
+        controller.enqueue(contents)
+        controller.close()
+      },
+    })
+  }
+}
+
+export class StringOpener extends BytesOpener {
+  constructor(contents: string) {
+    super(textEncoder.encode(contents))
+  }
+}
+
+export class StreamOpener implements FileOpener {
+  #stream: ReadableStream<Uint8Array<ArrayBuffer>>
+  size: number
+
+  constructor(stream: ReadableStream<Uint8Array<ArrayBuffer>>, size: number) {
+    this.#stream = stream
+    this.size = size
+  }
+
+  async stream(): Promise<ReadableStream<Uint8Array<ArrayBuffer>>> {
+    const tee = this.#stream.tee()
+    this.#stream = tee[1]
+    return tee[0]
+  }
+
+  async text(): Promise<string> {
+    const stream = await this.stream()
+    const reader = stream.pipeThrough(createUTF8Stream()).getReader()
+    const chunks: string[] = []
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        chunks.push(value)
+      }
+      return chunks.join('')
+    } finally {
+      reader.releaseLock()
+    }
+  }
+
+  // Not a thoroughly tested implementation
+  // Do not move this out of test files without adding more substantial tests
+  async readBytes(size: number, offset = 0): Promise<Uint8Array<ArrayBuffer>> {
+    const stream = await this.stream()
+    const reader = stream.getReader()
+    const result = new Uint8Array(size)
+    let pos = 0
+    try {
+      while (pos < offset + size) {
+        const { done, value } = await reader.read()
+        if (done) break
+        if (pos + value.length > offset) {
+          result.set(
+            value.subarray(Math.max(0, offset - pos), Math.min(value.length, offset + size - pos)),
+            Math.max(0, pos - offset),
+          )
+        }
+        pos += value.length
+      }
+    } finally {
+      reader.releaseLock()
+    }
+    return result.subarray(0, Math.min(size, pos - offset))
+  }
+}
+
+export class CompressedStringOpener extends StreamOpener {
+  constructor(contents: string) {
+    // Use uncompressed length as size, for simplicity
+    super(streamFromString(contents).pipeThrough(new CompressionStream('gzip')), contents.length)
+  }
+}
+
+async function testOpener(t: Deno.TestContext, opener: FileOpener) {
+  await t.step('size', async () => {
+    assertEquals(opener.size, 13)
+  })
+  await t.step('text()', async () => {
+    assertEquals(await opener.text(), 'Hello, world!')
+  })
+  await t.step('readBytes()', async () => {
+    assertEquals(textDecoder.decode(await opener.readBytes(5)), 'Hello')
+    assertEquals(textDecoder.decode(await opener.readBytes(7, 5)), ', world')
+  })
+  await t.step('stream()', async () => {
+    const stream = await opener.stream()
+    const chunks: string[] = []
+    for await (const chunk of stream) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+    assertEquals(chunks.join(''), 'Hello, world!')
+  })
+}
+
+Deno.test('Validate BytesOpener', async (t) => {
+  await testOpener(t, new BytesOpener(textEncoder.encode('Hello, world!')))
+})
+
+Deno.test('Validate StringOpener', async (t) => {
+  await testOpener(t, new StringOpener('Hello, world!'))
+})
+
+Deno.test('Validate StreamOpener', async (t) => {
+  await testOpener(t, new StreamOpener(streamFromString('Hello, world!'), 13))
+})
+
+Deno.test('Validate CompressedStringOpener', async (t) => {
+  const opener = new CompressedStringOpener('Hello, world!')
+  await t.step('Decompress', async () => {
+    const stream = await opener.stream()
+    const decompressedStream = stream.pipeThrough(new DecompressionStream('gzip'))
+    const chunks: string[] = []
+    for await (const chunk of decompressedStream) {
+      chunks.push(textDecoder.decode(chunk))
+    }
+    assertEquals(chunks.join(''), 'Hello, world!')
+  })
+})

--- a/src/files/tsv.test.ts
+++ b/src/files/tsv.test.ts
@@ -8,22 +8,14 @@ import {
 import { pathToFile } from './filetree.test.ts'
 import { BIDSFileDeno } from './deno.ts'
 import { loadTSV, loadTSVGZ } from './tsv.ts'
-import { asyncStreamFromString } from '../tests/utils.ts'
 import { ColumnsMap } from '../types/columns.ts'
 import { testAsyncFileAccess } from './access.test.ts'
-
-async function compressedStreamFromString(
-  str: string,
-): Promise<ReadableStream<Uint8Array<ArrayBuffer>>> {
-  return asyncStreamFromString(str).then((stream) =>
-    stream.pipeThrough(new CompressionStream('gzip')) as ReadableStream<Uint8Array<ArrayBuffer>>
-  )
-}
+import { CompressedStringOpener, StringOpener } from './openers.test.ts'
 
 Deno.test('TSV loading', async (t) => {
   await t.step('Empty file produces empty map', async () => {
     const file = pathToFile('/empty.tsv')
-    file.opener.stream = () => asyncStreamFromString('')
+    file.opener = new StringOpener('')
 
     const map = await loadTSV(file)
     // map.size looks for a column called map, so work around it
@@ -32,7 +24,7 @@ Deno.test('TSV loading', async (t) => {
 
   await t.step('Single row file produces header-only map', async () => {
     const file = pathToFile('/single_row.tsv')
-    file.opener.stream = () => asyncStreamFromString('a\tb\tc\n')
+    file.opener = new StringOpener('a\tb\tc\n')
 
     const map = await loadTSV(file)
     assertEquals(map.a, [])
@@ -42,7 +34,7 @@ Deno.test('TSV loading', async (t) => {
 
   await t.step('Single column file produces single column map', async () => {
     const file = pathToFile('/single_column.tsv')
-    file.opener.stream = () => asyncStreamFromString('a\n1\n2\n3\n')
+    file.opener = new StringOpener('a\n1\n2\n3\n')
 
     const map = await loadTSV(file)
     assertEquals(map.a, ['1', '2', '3'])
@@ -50,7 +42,7 @@ Deno.test('TSV loading', async (t) => {
 
   await t.step('Missing final newline is ignored', async () => {
     const file = pathToFile('/missing_newline.tsv')
-    file.opener.stream = () => asyncStreamFromString('a\n1\n2\n3')
+    file.opener = new StringOpener('a\n1\n2\n3')
 
     const map = await loadTSV(file)
     assertEquals(map.a, ['1', '2', '3'])
@@ -58,7 +50,7 @@ Deno.test('TSV loading', async (t) => {
 
   await t.step('Empty row throws issue', async () => {
     const file = pathToFile('/empty_row.tsv')
-    file.opener.stream = () => asyncStreamFromString('a\tb\tc\n1\t2\t3\n\n4\t5\t6\n')
+    file.opener = new StringOpener('a\tb\tc\n1\t2\t3\n\n4\t5\t6\n')
 
     try {
       await loadTSV(file)
@@ -69,7 +61,7 @@ Deno.test('TSV loading', async (t) => {
 
   await t.step('Mismatched row length throws issue', async () => {
     const file = pathToFile('/mismatched_row.tsv')
-    file.opener.stream = () => asyncStreamFromString('a\tb\tc\n1\t2\t3\n4\t5\n')
+    file.opener = new StringOpener('a\tb\tc\n1\t2\t3\n4\t5\n')
 
     try {
       await loadTSV(file)
@@ -82,7 +74,7 @@ Deno.test('TSV loading', async (t) => {
     const file = pathToFile('/long.tsv')
     // Use 1500 to avoid overlap with default initial capacity
     const text = 'a\tb\tc\n' + '1\t2\t3\n'.repeat(1500)
-    file.opener.stream = () => asyncStreamFromString(text)
+    file.opener = new StringOpener(text)
 
     let map = await loadTSV(file, 0)
     assertEquals(map.a, [])
@@ -91,21 +83,18 @@ Deno.test('TSV loading', async (t) => {
 
     // Do not assume that caching respects maxRows in this test
     loadTSV.cache.clear()
-    file.opener.stream = () => asyncStreamFromString(text)
     map = await loadTSV(file, 1)
     assertEquals(map.a, ['1'])
     assertEquals(map.b, ['2'])
     assertEquals(map.c, ['3'])
 
     loadTSV.cache.clear()
-    file.opener.stream = () => asyncStreamFromString(text)
     map = await loadTSV(file, 2)
     assertEquals(map.a, ['1', '1'])
     assertEquals(map.b, ['2', '2'])
     assertEquals(map.c, ['3', '3'])
 
     loadTSV.cache.clear()
-    file.opener.stream = () => asyncStreamFromString(text)
     map = await loadTSV(file, -1)
     assertEquals(map.a, Array(1500).fill('1'))
     assertEquals(map.b, Array(1500).fill('2'))
@@ -113,7 +102,7 @@ Deno.test('TSV loading', async (t) => {
 
     loadTSV.cache.clear()
     // Check that maxRows does not truncate shorter files
-    file.opener.stream = () => asyncStreamFromString('a\tb\tc\n1\t2\t3\n4\t5\t6\n7\t8\t9\n')
+    file.opener = new StringOpener('a\tb\tc\n1\t2\t3\n4\t5\t6\n7\t8\t9\n')
     map = await loadTSV(file, 4)
     assertEquals(map.a, ['1', '4', '7'])
     assertEquals(map.b, ['2', '5', '8'])
@@ -125,7 +114,7 @@ Deno.test('TSV loading', async (t) => {
     const file = pathToFile('/long.tsv')
     // Use 1500 to avoid overlap with default initial capacity
     const text = 'a\tb\tc\n' + '1\t2\t3\n'.repeat(1500)
-    file.opener.stream = () => asyncStreamFromString(text)
+    file.opener = new StringOpener(text)
 
     let map = await loadTSV(file, 2)
     assertEquals(map.a, ['1', '1'])
@@ -133,7 +122,6 @@ Deno.test('TSV loading', async (t) => {
     assertEquals(map.c, ['3', '3'])
 
     // Replace stream to ensure cache does not depend on deep object equality
-    file.opener.stream = () => asyncStreamFromString(text)
     let repeatMap = await loadTSV(file, 2)
     assertStrictEquals(map, repeatMap)
 
@@ -151,21 +139,19 @@ Deno.test('TSV loading', async (t) => {
     const file = pathToFile('/long.tsv')
     // Use 1500 to avoid overlap with default initial capacity
     const text = 'a\tb\tc\n' + '1\t2\t3\n'.repeat(1500)
-    file.opener.stream = () => asyncStreamFromString(text)
+    file.opener = new StringOpener(text)
 
     let map = await loadTSV(file, 2)
     assertEquals(map.a, ['1', '1'])
     assertEquals(map.b, ['2', '2'])
     assertEquals(map.c, ['3', '3'])
 
-    file.opener.stream = () => asyncStreamFromString(text)
     let repeatMap = await loadTSV(file, 3)
     assertNotStrictEquals(map, repeatMap)
     assertEquals(repeatMap.a, ['1', '1', '1'])
     assertEquals(repeatMap.b, ['2', '2', '2'])
     assertEquals(repeatMap.c, ['3', '3', '3'])
 
-    file.opener.stream = () => asyncStreamFromString(text)
     repeatMap = await loadTSV(file, 2)
     assertStrictEquals(map, repeatMap)
     assertEquals(repeatMap.a, ['1', '1'])
@@ -175,7 +161,7 @@ Deno.test('TSV loading', async (t) => {
 
   await t.step('Raises issue on duplicate header', async () => {
     const file = pathToFile('/duplicate_header.tsv')
-    file.opener.stream = () => asyncStreamFromString('a\ta\n1\t2\n')
+    file.opener = new StringOpener('a\ta\n1\t2\n')
 
     try {
       await loadTSV(file)
@@ -203,7 +189,7 @@ Deno.test('TSV loading', async (t) => {
 Deno.test('TSVGZ loading', async (t) => {
   await t.step('No header and empty file produces empty map', async () => {
     const file = pathToFile('/empty.tsv.gz')
-    file.opener.stream = () => compressedStreamFromString('')
+    file.opener = new CompressedStringOpener('')
 
     const map = await loadTSVGZ(file, [])
     // map.size looks for a column called map, so work around it
@@ -212,7 +198,7 @@ Deno.test('TSVGZ loading', async (t) => {
 
   await t.step('Empty file produces header-only map', async () => {
     const file = pathToFile('/empty.tsv.gz')
-    file.opener.stream = () => compressedStreamFromString('')
+    file.opener = new CompressedStringOpener('')
 
     const map = await loadTSVGZ(file, ['a', 'b', 'c'])
     assertEquals(map.a, [])
@@ -222,7 +208,7 @@ Deno.test('TSVGZ loading', async (t) => {
 
   await t.step('Single column file produces single column maps', async () => {
     const file = pathToFile('/single_column.tsv')
-    file.opener.stream = () => compressedStreamFromString('1\n2\n3\n')
+    file.opener = new CompressedStringOpener('1\n2\n3\n')
 
     const map = await loadTSVGZ(file, ['a'])
     assertEquals(map.a, ['1', '2', '3'])
@@ -230,7 +216,7 @@ Deno.test('TSVGZ loading', async (t) => {
 
   await t.step('Mismatched header length throws issue', async () => {
     const file = pathToFile('/single_column.tsv.gz')
-    file.opener.stream = () => compressedStreamFromString('1\n2\n3\n')
+    file.opener = new CompressedStringOpener('1\n2\n3\n')
 
     try {
       await loadTSVGZ(file, ['a', 'b'])
@@ -241,7 +227,7 @@ Deno.test('TSVGZ loading', async (t) => {
 
   await t.step('Missing final newline is ignored', async () => {
     const file = pathToFile('/missing_newline.tsv.gz')
-    file.opener.stream = () => compressedStreamFromString('1\n2\n3')
+    file.opener = new CompressedStringOpener('1\n2\n3')
 
     const map = await loadTSVGZ(file, ['a'])
     assertEquals(map.a, ['1', '2', '3'])
@@ -249,7 +235,7 @@ Deno.test('TSVGZ loading', async (t) => {
 
   await t.step('Empty row throws issue', async () => {
     const file = pathToFile('/empty_row.tsv.gz')
-    file.opener.stream = () => compressedStreamFromString('1\t2\t3\n\n4\t5\t6\n')
+    file.opener = new CompressedStringOpener('1\t2\t3\n\n4\t5\t6\n')
 
     try {
       await loadTSVGZ(file, ['a', 'b', 'c'])
@@ -260,7 +246,7 @@ Deno.test('TSVGZ loading', async (t) => {
 
   await t.step('Mislabeled TSV throws issue', async () => {
     const file = pathToFile('/mismatched_row.tsv.gz')
-    file.opener.stream = () => asyncStreamFromString('a\tb\tc\n1\t2\t3\n4\t5\n')
+    file.opener = new StringOpener('a\tb\tc\n1\t2\t3\n4\t5\n')
 
     try {
       await loadTSVGZ(file, ['a', 'b', 'c'])
@@ -274,33 +260,30 @@ Deno.test('TSVGZ loading', async (t) => {
     // Use 1500 to avoid overlap with default initial capacity
     const headers = ['a', 'b', 'c']
     const text = '1\t2\t3\n'.repeat(1500)
-    file.opener.stream = () => compressedStreamFromString(text)
+    file.opener = new CompressedStringOpener(text)
 
     let map = await loadTSVGZ(file, headers, 0)
     assertEquals(map.a, [])
     assertEquals(map.b, [])
     assertEquals(map.c, [])
 
-    file.opener.stream = () => compressedStreamFromString(text)
     map = await loadTSVGZ(file, headers, 1)
     assertEquals(map.a, ['1'])
     assertEquals(map.b, ['2'])
     assertEquals(map.c, ['3'])
 
-    file.opener.stream = () => compressedStreamFromString(text)
     map = await loadTSVGZ(file, headers, 2)
     assertEquals(map.a, ['1', '1'])
     assertEquals(map.b, ['2', '2'])
     assertEquals(map.c, ['3', '3'])
 
-    file.opener.stream = () => compressedStreamFromString(text)
     map = await loadTSVGZ(file, headers, -1)
     assertEquals(map.a, Array(1500).fill('1'))
     assertEquals(map.b, Array(1500).fill('2'))
     assertEquals(map.c, Array(1500).fill('3'))
 
     // Check that maxRows does not truncate shorter files
-    file.opener.stream = () => compressedStreamFromString('1\t2\t3\n4\t5\t6\n7\t8\t9\n')
+    file.opener = new CompressedStringOpener('1\t2\t3\n4\t5\t6\n7\t8\t9\n')
     map = await loadTSVGZ(file, headers, 4)
     assertEquals(map.a, ['1', '4', '7'])
     assertEquals(map.b, ['2', '5', '8'])

--- a/src/tests/regression.test.ts
+++ b/src/tests/regression.test.ts
@@ -2,7 +2,7 @@ import { assert } from '@std/assert'
 import { pathsToTree } from '../files/filetree.test.ts'
 import { validate } from '../validators/bids.ts'
 import type { BIDSFile } from '../types/filetree.ts'
-import { asyncStreamFromString } from './utils.ts'
+import { StringOpener } from '../files/openers.test.ts'
 
 Deno.test('Regression tests', async (t) => {
   await t.step('Verify ignored files in scans.tsv do not trigger error', async () => {
@@ -18,7 +18,7 @@ Deno.test('Regression tests', async (t) => {
     // Without ignore, NOT_INCLUDED is triggered for CT, but the scans file is happy
     let ds = pathsToTree(paths)
     let scans_tsv = ds.get('sub-01/sub-01_scans.tsv') as BIDSFile
-    scans_tsv.opener.stream = () => asyncStreamFromString(scans_content)
+    scans_tsv.opener = new StringOpener(scans_content)
     let result = await validate(ds, {
       datasetPath: '/dataset',
       debug: 'ERROR',
@@ -32,7 +32,7 @@ Deno.test('Regression tests', async (t) => {
     // With ignore, NOT_INCLUDED is not triggered for CT, and the scans file is still happy
     ds = pathsToTree(paths, ignore)
     scans_tsv = ds.get('sub-01/sub-01_scans.tsv') as BIDSFile
-    scans_tsv.opener.stream = () => asyncStreamFromString(scans_content)
+    scans_tsv.opener = new StringOpener(scans_content)
     result = await validate(ds, {
       datasetPath: '/dataset',
       debug: 'ERROR',

--- a/src/tests/utils.ts
+++ b/src/tests/utils.ts
@@ -12,9 +12,3 @@ export function streamFromUint8Array<T extends ArrayBufferLike>(
 export function streamFromString(str: string): ReadableStream<Uint8Array<ArrayBuffer>> {
   return streamFromUint8Array(new TextEncoder().encode(str) as Uint8Array<ArrayBuffer>)
 }
-
-export async function asyncStreamFromString(
-  str: string,
-): Promise<ReadableStream<Uint8Array<ArrayBuffer>>> {
-  return Promise.resolve(streamFromString(str))
-}

--- a/src/validators/validateFiles.test.ts
+++ b/src/validators/validateFiles.test.ts
@@ -7,13 +7,16 @@ import type { GenericSchema, Schema } from '../types/schema.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
 import type { BIDSFile } from '../types/filetree.ts'
 import { pathsToTree } from '../files/filetree.test.ts'
+import { StringOpener } from '../files/openers.test.ts'
 
 const schema = await loadSchema()
 
-function makeContext(path: string): BIDSContext {
+function makeContext(path: string, contents: string = ''): BIDSContext {
   const tree = pathsToTree([path])
   const dataset = new BIDSContextDataset({ schema, tree })
-  return new BIDSContext(tree.get(path) as BIDSFile, dataset)
+  const file = tree.get(path) as BIDSFile
+  file.opener = new StringOpener(contents)
+  return new BIDSContext(file, dataset)
 }
 
 Deno.test('test valid paths', async (t) => {


### PR DESCRIPTION
Pulled out of #282 (and expanded) to keep that one focused.