### PR TITLE
feat: Support min/max of single numbers

### DIFF
--- a/changelog.d/20251028_125514_markiewicz_minmax.md
+++ b/changelog.d/20251028_125514_markiewicz_minmax.md
@@ -1,0 +1,35 @@
+### Changed
+
+- Support `min()` and `max()` of numbers in the expression language.
+  This allows for simpler rules when a field may be a number or array of numbers.
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/schema/expressionLanguage.ts
+++ b/src/schema/expressionLanguage.ts
@@ -79,11 +79,23 @@ export const expressionFunctions = {
     }
     return typeof operand
   },
-  min: (list: number[]): number | null => {
-    return list != null ? Math.min(...list.map(Number).filter((x) => !isNaN(x))) : null
+  min: (list: number | number[]): number | null => {
+    if (list == null) {
+      return null
+    }
+    if (!Array.isArray(list)) {
+      list = [list]
+    }
+    return Math.min(...list.map(Number).filter((x) => !isNaN(x)))
   },
-  max: (list: number[]): number | null => {
-    return list != null ? Math.max(...list.map(Number).filter((x) => !isNaN(x))) : null
+  max: (list: number | number[]): number | null => {
+    if (list == null) {
+      return null
+    }
+    if (!Array.isArray(list)) {
+      list = [list]
+    }
+    return Math.max(...list.map(Number).filter((x) => !isNaN(x)))
   },
   length: <T>(list: T[]): number | null => {
     if (Array.isArray(list) || typeof list == 'string') {


### PR DESCRIPTION
This supports expressions that involve variables that may be a number or array of numbers. This is consistent with Javascript and numpy's min/max implementations and does not have obvious trip-ups. The schema will soon include an expression test to verify this functionality.

xref https://github.com/bids-standard/bids-specification/pull/2235