### PR TITLE
feat: Fall back to an empty file for absent symlinks with no public S3 URL

### DIFF
--- a/changelog.d/20251030_132706_markiewicz_s3.md
+++ b/changelog.d/20251030_132706_markiewicz_s3.md
@@ -1,0 +1,5 @@
+### Changed
+
+- [Annexed](https://git-annex.branchable.com/) files that are not local are treated as
+  empty instead of erroring if a remote URL could not be constructed. The size of missing
+  files are included in the summary estimate of dataset size.

--- a/src/files/openers.ts
+++ b/src/files/openers.ts
@@ -126,3 +126,18 @@ export class HTTPOpener implements FileOpener {
     return new Uint8Array(await response.arrayBuffer())
   }
 }
+
+export class NullFileOpener implements FileOpener {
+  size: number
+  constructor(size = 0) {
+    this.size = size
+  }
+  stream = async () =>
+    new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    })
+  text = async () => ''
+  readBytes = async (size: number, offset?: number) => new Uint8Array()
+}

--- a/src/schema/walk.ts
+++ b/src/schema/walk.ts
@@ -1,6 +1,7 @@
 import { BIDSContext, type BIDSContextDataset } from './context.ts'
-import { BIDSFile, FileOpener, FileTree } from '../types/filetree.ts'
+import { BIDSFile, type FileTree } from '../types/filetree.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
+import { NullFileOpener } from '../files/openers.ts'
 import { loadTSV } from '../files/tsv.ts'
 import { loadJSON } from '../files/json.ts'
 import { queuedAsyncIterator } from '../utils/queue.ts'
@@ -12,21 +13,6 @@ function* quickWalk(dir: FileTree): Generator<BIDSFile> {
   for (const subdir of dir.directories) {
     yield* quickWalk(subdir)
   }
-}
-
-class NullFileOpener implements FileOpener {
-  size: number
-  constructor(size = 0) {
-    this.size = size
-  }
-  stream = async () =>
-    new ReadableStream({
-      start(controller) {
-        controller.close()
-      },
-    })
-  text = async () => ''
-  readBytes = async (size: number, offset?: number) => new Uint8Array()
 }
 
 function pseudoFile(dir: FileTree, opaque: boolean): BIDSFile {


### PR DESCRIPTION
This should minimally resolve @bpinsard's issue in #286 while also reporting the size of absent files.

I don't know if we should log warnings? The fact that we couldn't open it should be reflected as `EMPTY_FILE` or other failures to load contents, for the most part.