### PR TITLE
chore(ci): Build against macos-15-intel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -45,7 +45,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - windows-latest
-          - macos-13
+          - macos-15-intel
           - macos-latest
       fail-fast: false
     permissions:


### PR DESCRIPTION
macos-13 is undergoing a brownout. Looks like we can use `macos-15-intel` for now. Once that's gone, so will be x86-64 wheels for mac. :shrug:

* https://github.com/actions/runner-images/issues/13046