### PR TITLE
fix: Add missing INVALID_FILE_ENCODING issue definition

### DIFF
--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -203,6 +203,10 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'Files with the same name but different casing have been found.',
   },
+  INVALID_FILE_ENCODING: {
+    severity: 'error',
+    reason: 'File encoding is not valid UTF-8.',
+  },
 }
 
 export const nonSchemaIssues = { ...bidsIssues }


### PR DESCRIPTION
Seeing this crash on a number of OpenNeuro datasets.

```Error: key: INVALID_FILE_ENCODING does not exist in non-schema issues definitions```