### PR TITLE
chore: Revert to upstream nifti-reader-js

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -43,6 +43,30 @@ const versionPlugin = {
   },
 }
 
+/**
+ * Resolve fflate (a nifti-reader-js dependency) to its browser build.
+ *
+ * Deno's npm resolver applies the "node" export condition, which selects a
+ * build that imports `createRequire` from node:module to load worker_threads.
+ * That import survives bundling and breaks downstream browser bundlers. Only
+ * the synchronous API is used here, so the browser build is equivalent.
+ *
+ * Must precede denoPlugin: esbuild's `alias` option never runs because
+ * denoPlugin claims these paths in onResolve first.
+ */
+const fflateBrowserPlugin = {
+  name: 'fflate-browser',
+  setup(build: esbuild.PluginBuild) {
+    build.onResolve({ filter: /^fflate$/ }, (args) =>
+      build.resolve('fflate/browser', {
+        importer: args.importer,
+        kind: args.kind,
+        resolveDir: args.resolveDir,
+      })
+    )
+  },
+}
+
 const result = await esbuild.build({
   splitting: true,
   format: 'esm',
@@ -52,6 +76,7 @@ const result = await esbuild.build({
   minify: flags.minify,
   target: ['chrome109', 'firefox109', 'safari16'],
   plugins: [
+    fflateBrowserPlugin,
     nodeModulesPolyfillPlugin({
       globals: {
         Buffer: true,

--- a/changelog.d/20260910_125303_markiewicz_upstream_nifti.md
+++ b/changelog.d/20260910_125303_markiewicz_upstream_nifti.md
@@ -1,0 +1,5 @@
+### Infrastructure
+
+- Drop fork of [nifti-reader-js][] and depend on upstream module.
+
+[nifti-reader-js]: https://www.npmjs.com/package/nifti-reader-js

--- a/deno.json
+++ b/deno.json
@@ -48,7 +48,7 @@
     "pluralize": "npm:pluralize@^8.0.0",
     "@ignore": "npm:ignore@^7.0.6",
     "@libs/xml": "jsr:@libs/xml@^7.0.4",
-    "@mango/nifti": "npm:@bids/nifti-reader-js@^0.6.9",
+    "@mango/nifti": "npm:nifti-reader-js@^0.8.0",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/async": "jsr:@std/async@^1.5.0",
     "@std/fmt": "jsr:@std/fmt@^1.0.10",

--- a/deno.lock
+++ b/deno.lock
@@ -6,6 +6,8 @@
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
+    "jsr:@deno/esbuild-plugin@1.1.5": "1.1.5",
+    "jsr:@deno/loader@~0.3.3": "0.3.14",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
@@ -26,6 +28,7 @@
     "jsr:@std/io@~0.225.2": "0.225.3",
     "jsr:@std/io@~0.225.3": "0.225.3",
     "jsr:@std/log@~0.224.14": "0.224.14",
+    "jsr:@std/path@^1.1.1": "1.1.6",
     "jsr:@std/path@^1.1.5": "1.1.6",
     "jsr:@std/path@^1.1.6": "1.1.6",
     "jsr:@std/streams@^1.0.14": "1.0.14",
@@ -33,7 +36,6 @@
     "jsr:@std/testing@^1.0.20": "1.0.20",
     "jsr:@std/text@~1.0.7": "1.0.19",
     "jsr:@std/yaml@^1.2.0": "1.2.0",
-    "npm:@bids/nifti-reader-js@~0.6.9": "0.6.9",
     "npm:@types/node@*": "24.2.0",
     "npm:ajv@8.20.0": "8.20.0",
     "npm:ansi-escapes@^7.3.0": "7.3.0",
@@ -43,6 +45,7 @@
     "npm:ignore@^7.0.6": "7.0.6",
     "npm:isomorphic-git@^1.41.7": "1.41.7",
     "npm:marked@^17.0.6": "17.0.6",
+    "npm:nifti-reader-js@0.8": "0.8.0",
     "npm:pluralize@8": "8.0.0",
     "npm:supports-hyperlinks@^4.5.0": "4.5.0"
   },
@@ -67,6 +70,16 @@
       "dependencies": [
         "jsr:@std/fmt@~1.0.2"
       ]
+    },
+    "@deno/esbuild-plugin@1.1.5": {
+      "integrity": "c9cde95990b97802a0da6c73c26ab4a48f30d286818845e365dddcd8297abd7d",
+      "dependencies": [
+        "jsr:@deno/loader",
+        "jsr:@std/path@^1.1.1"
+      ]
+    },
+    "@deno/loader@0.3.14": {
+      "integrity": "97bc63a6cc2d27a60bcdc953f588c5213331d866d44212eebb24cebfb9b011ca"
     },
     "@effigies/cliffy-command@1.0.0-dev.8": {
       "integrity": "d6489c66bf7f603225a426b26b62eaee32bf6da04b69056bcb015a1f17190087",
@@ -164,12 +177,6 @@
     }
   },
   "npm": {
-    "@bids/nifti-reader-js@0.6.9": {
-      "integrity": "sha512-3KWpGKrgUUvT5Bbl25K9TTQ77DRS5DUpcyhZlAblCPdP1YMy0tCzrxarRTixWM9tDN6sWUOBbf6zQpPyVe11Lw==",
-      "dependencies": [
-        "fflate"
-      ]
-    },
     "@esbuild/aix-ppc64@0.25.10": {
       "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
       "os": ["aix"],
@@ -511,8 +518,8 @@
       ],
       "bin": true
     },
-    "fflate@0.8.2": {
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
+    "fflate@0.8.3": {
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="
     },
     "for-each@0.3.5": {
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
@@ -667,6 +674,12 @@
         "pathe",
         "pkg-types@1.3.1",
         "ufo"
+      ]
+    },
+    "nifti-reader-js@0.8.0": {
+      "integrity": "sha512-iO1iIhQDfKniy+l/86HfOPte7So+SxBmBiMSiUB2VXU7z4hSewMTlE3h0fCgfzfXvMUa+ilzLTJ2ZHmtFw6EWw==",
+      "dependencies": [
+        "fflate"
       ]
     },
     "once@1.4.0": {
@@ -936,7 +949,6 @@
       "jsr:@std/streams@^1.1.2",
       "jsr:@std/testing@^1.0.20",
       "jsr:@std/yaml@^1.2.0",
-      "npm:@bids/nifti-reader-js@~0.6.9",
       "npm:ajv@8.20.0",
       "npm:ansi-escapes@^7.3.0",
       "npm:hash-wasm@^4.12.0",
@@ -944,6 +956,7 @@
       "npm:ignore@^7.0.6",
       "npm:isomorphic-git@^1.41.7",
       "npm:marked@^17.0.6",
+      "npm:nifti-reader-js@0.8",
       "npm:pluralize@8",
       "npm:supports-hyperlinks@^4.5.0"
     ]

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import "./App.css";
 import { directoryOpen } from "https://esm.sh/browser-fs-access@0.35.0";
-import confetti from "npm:canvas-confetti@1.9.3";
+import confetti from "canvas-confetti";
 import Markdown from "react-markdown";
 import { fileListToTree, getVersion, validate } from "../dist/validator/web.js";
 import type { ValidationResult } from "../../src/types/validation-result.ts";

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -2,11 +2,23 @@ import { defineConfig } from "npm:vite@^5.0.10"
 import react from "npm:@vitejs/plugin-react@^4.2.1"
 import httpsImports from "npm:vite-plugin-https-imports@0.1.0"
 import { nodePolyfills } from "npm:vite-plugin-node-polyfills@0.22.0"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 
+// Side-effect imports that exist only to make Deno install these into
+// node_modules, where Vite can resolve them as bare specifiers.
 import "npm:react@^18.2.0"
 import "npm:react-dom@^18.2.0"
 import "npm:react-markdown@^10.1.0"
-import "npm:canvas-confetti@1.9.3"
+
+// canvas-confetti cannot be pinned the same way: Deno exposes an
+// OffscreenCanvas whose 2D context is null, so the package's SSR guard passes
+// and it crashes on load while Vite is reading this config. Resolving it
+// installs it without executing it, and the alias below lets Vite find it
+// despite the missing top-level node_modules link.
+const canvasConfetti = path.dirname(
+  fileURLToPath(import.meta.resolve("npm:canvas-confetti@1.9.3/package.json")),
+)
 
 /**
  * Vite plugin to hack a bug injected by the default assetImportMetaUrlPlugin
@@ -35,12 +47,7 @@ export default defineConfig({
         globals: { Buffer: true }
     })
   ],
-  build: {
-    // ... other configurations
-    resolve: {
-      alias: {
-        "^npm:": "./node_modules/", // or path to your node_modules directory
-      },
-    },
+  resolve: {
+    alias: { "canvas-confetti": canvasConfetti },
   },
 })


### PR DESCRIPTION
Updating to `nifti-reader-js@^0.8.0` led to two failures, though apparently one was unrelated:

* The `canvas-confetti` dependency broke `deno task build` in the web. I don't understand why it was working before but not now.
* `nifti-reader-js` switched from `pako` to `fflate`, which needs some handling for esbuild.

This was annoying, and ultimately I had to sic Claude on figuring out how to resolve it. A second pair of eyes would be appreciated.