### PR TITLE
fix: Set nifti_header.axis_codes to null for bad qforms, rather than error

### DIFF
--- a/changelog.d/20251124_080614_markiewicz_bad_qform.md
+++ b/changelog.d/20251124_080614_markiewicz_bad_qform.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- NIfTI files with bad qform matrices, resulting from non-normalized quaternions,
+  would previously raise a NIFTI_HEADER_UNREADABLE error. Now only the axis codes
+  are disabled, preventing orientation checks, but not raising errors.

--- a/src/files/nifti.test.ts
+++ b/src/files/nifti.test.ts
@@ -96,6 +96,10 @@ Deno.test('Test extracting axis codes', async (t) => {
     const affine = [[0, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]]
     assertEquals(axisCodes(affine), ['A', 'S', 'R'])
   })
+  await t.step('Fail gracefully on NaNs', async () => {
+    const affine = [[Number.NaN, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]]
+    assertEquals(axisCodes(affine), null)
+  })
 })
 
 testAsyncFileAccess('Test file access errors for loadHeader', loadHeader)

--- a/src/files/nifti.ts
+++ b/src/files/nifti.ts
@@ -125,12 +125,17 @@ function argMax(arr: number[]): number {
  *
  * @returns character codes describing the orientation of an image affine.
  */
-export function axisCodes(affine: number[][]): string[] {
+export function axisCodes(affine: number[][]): string[] | null {
   // This function is an extract of the Python function transforms3d.affines.decompose44
   // (https://github.com/matthew-brett/transforms3d/blob/6a43a98/transforms3d/affines.py#L10-L153)
   //
   // As an optimization, this only orthogonalizes the basis,
   // and does not normalize to unit vectors.
+
+  // Bad qforms result in NaNs in the rotation matrix
+  if (affine.some((row) => row.some((val) => !Number.isFinite(val)))) {
+    return null
+  }
 
   // Operate on columns, which are the cosines that project input coordinates onto output axes
   const [cosX, cosY, cosZ] = [0, 1, 2].map((j) => [0, 1, 2].map((i) => affine[i][j]))


### PR DESCRIPTION
In #112 we added `axis_codes` to the `nifti_header` context, which unwittingly made the whole header appear unreadable for improper quaternions (the norm of the quaternion should be 1; if the norm of the explicit components exceeds 1, the implicit component can't be calculated). Raising an error in this case is not worth it, since it only enables a warning check.

I've seen two reports in the last week about surprising `NIFTI_HEADER_UNREADABLE` errors (OpenNeuro support ticket and https://neurostars.org/t/bids-validator-error-nifti-header-unreadable/34423), which result from this.