### PR TITLE
feat: Support base64-encoded S3 metadata

### DIFF
--- a/changelog.d/20251203_161616_markiewicz_b64.md
+++ b/changelog.d/20251203_161616_markiewicz_b64.md
@@ -1,0 +1,3 @@
+### Added
+
+- Annexed files with base-64-encoded version information are now supported.

--- a/src/files/repo.test.ts
+++ b/src/files/repo.test.ts
@@ -14,14 +14,15 @@ Deno.test('parseRmetLine', async (t) => {
     })
   })
   await t.step('parses base64-encoded rmet line', () => {
+    // Real example from OpenNeuro, has a unicode apostrophe in the filename
     const line =
-      '1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +!aVZjRWsxOGUzSjJXUXlzNHpyX0FOYVRQZnBVdWZXNFkjZHMwMDI3NzgvZGF0YXNldF9kZXNjcmlwdGlvbi5qc29u'
+      '1714730995.499196097s 51d08fb4-c58a-4fd7-a171-e5ff8226ca2f:V +!aG1NM2VqYWRxdFgxR18uc1VRNmJzd0FMLnhUcFJFeG8jZHMwMDQxOTQvZGVyaXZhdGl2ZXMvQnJhbmRzZXRhbDIwMjRUZW1wb3JhbEFkYXB0YXRpb25FQ29HL2RhdGFfc3ViamVjdHMvc3ViLXAxMS9lcG9jaHNfYi9lcG9jaHNfYl9jaGFubmVsMzItQW1iZXLigJlzIE1hY0Jvb2sgUHJvLnR4dA=='
     const entry = parseRmetLine(line)
     assertObjectMatch(entry!, {
-      timestamp: 1590213748.042921433,
-      uuid: '57894849-d0c8-4c62-8418-3627be18a196',
-      version: 'iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y',
-      path: 'ds002778/dataset_description.json',
+      timestamp: 1714730995.499196097,
+      uuid: '51d08fb4-c58a-4fd7-a171-e5ff8226ca2f',
+      version: 'hmM3ejadqtX1G_.sUQ6bswAL.xTpRExo',
+      path: 'ds004194/derivatives/Brandsetal2024TemporalAdaptationECoG/data_subjects/sub-p11/epochs_b/epochs_b_channel32-Amber’s MacBook Pro.txt'
     })
   })
 })

--- a/src/files/repo.test.ts
+++ b/src/files/repo.test.ts
@@ -1,0 +1,27 @@
+import { assert, assertArrayIncludes, assertObjectMatch } from '@std/assert'
+import { parseRmetLine } from './repo.ts'
+
+Deno.test('parseRmetLine', async (t) => {
+  await t.step('parses valid rmet line', () => {
+    const line =
+      '1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y#ds002778/dataset_description.json'
+    const entry = parseRmetLine(line)
+    assertObjectMatch(entry!, {
+      timestamp: 1590213748.042921433,
+      uuid: '57894849-d0c8-4c62-8418-3627be18a196',
+      version: 'iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y',
+      path: 'ds002778/dataset_description.json',
+    })
+  })
+  await t.step('parses base64-encoded rmet line', () => {
+    const line =
+      '1590213748.042921433s 57894849-d0c8-4c62-8418-3627be18a196:V +!aVZjRWsxOGUzSjJXUXlzNHpyX0FOYVRQZnBVdWZXNFkjZHMwMDI3NzgvZGF0YXNldF9kZXNjcmlwdGlvbi5qc29u'
+    const entry = parseRmetLine(line)
+    assertObjectMatch(entry!, {
+      timestamp: 1590213748.042921433,
+      uuid: '57894849-d0c8-4c62-8418-3627be18a196',
+      version: 'iVcEk18e3J2WQys4zr_ANaTPfpUufW4Y',
+      path: 'ds002778/dataset_description.json',
+    })
+  })
+})

--- a/src/files/repo.ts
+++ b/src/files/repo.ts
@@ -50,7 +50,7 @@ export function parseRmetLine(line: string): Rmet | null {
   let versionStr = match!.groups!.version_str as string
   // Base64 encoded version strings are prefixed with '!'
   if (versionStr.startsWith('!')) {
-    versionStr = atob(versionStr.slice(1))
+    versionStr = b64toUtf8(versionStr.slice(1))
   }
   const versionMatch = versionStr.match(versionRegex)
   return {
@@ -59,6 +59,12 @@ export function parseRmetLine(line: string): Rmet | null {
     version: versionMatch!.groups!.version,
     path: versionMatch!.groups!.path,
   }
+}
+
+function b64toUtf8(str: string): string {
+  const decoded = atob(str)
+  const bytes = Uint8Array.from({ length: decoded.length }, (_, i) => decoded.charCodeAt(i))
+  return textDecoder.decode(bytes)
 }
 
 /**


### PR DESCRIPTION
It can happen that the S3 metadata gets base64-encoded. We need to handle this.

@nellh You mentioned that this is to handle unicode filenames... Do you have any b64 data from OpenNeuro we can verify this for? Python handles unicode more straightforwardly than JS.