### PR TITLE
fix: Define AMBIGUOUS_AFFINE, make a warning, raise less often

### DIFF
--- a/changelog.d/20251209_143122_markiewicz_ambiguous_affine_error.md
+++ b/changelog.d/20251209_143122_markiewicz_ambiguous_affine_error.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- The AMBIGUOUS_AFFINE issue was given an error message and set to warning.
+- Very oblique affines are no longer considered ambiguous.

--- a/src/files/nifti.test.ts
+++ b/src/files/nifti.test.ts
@@ -100,6 +100,25 @@ Deno.test('Test extracting axis codes', async (t) => {
     const affine = [[Number.NaN, 0, 1, 0], [1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1]]
     assertEquals(axisCodes(affine), null)
   })
+  await t.step('Consistently label very oblique axes', async () => {
+    // The i and k axes both move most along the z axis.
+    let affine = [
+      [ 0.63260427,  0.43813722,  0.63862948, 0],
+      [-0.31581750,  0.89885806, -0.30383137, 0],
+      [-0.70715708, -0.00948534,  0.70699285, 0],
+      [0, 0, 0, 1],
+    ]
+    assertEquals(axisCodes(affine), ['I', 'A', 'R'])
+    affine = [
+      [ 0.63862948,  0.43813722, -0.63260427, 0],
+      [-0.30383137,  0.89885806,  0.31581750, 0],
+      [ 0.70699285, -0.00948534,  0.70715708, 0],
+      [0, 0, 0, 1],
+    ]
+    // Naive ordering would call this SAL, but the largest magnitude method
+    // would label k before i.
+    assertEquals(axisCodes(affine), ['R', 'A', 'S'])
+  })
 })
 
 testAsyncFileAccess('Test file access errors for loadHeader', loadHeader)

--- a/src/files/nifti.ts
+++ b/src/files/nifti.ts
@@ -154,7 +154,7 @@ export function axisCodes(affine: number[][]): string[] | null {
 
   // Check that indices are 0, 1 and 2 in some order
   if (maxIndices.toSorted().some((idx, i) => idx !== i)) {
-    throw { code: 'AMBIGUOUS_AFFINE' }
+    return null
   }
 
   // Positive/negative codes for each world axis

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -146,6 +146,11 @@ export const bidsIssues: IssueDefinitionRecord = {
     reason:
       'We were unable to parse header data from this NIfTI file. Please ensure it is not corrupted or mislabeled.',
   },
+  AMBIGUOUS_AFFINE: {
+    severity: 'warning',
+    reason:
+      'The image orientation could not be determined. This may be the result of an invalid affine matrix.',
+  },
   CHECK_ERROR: {
     severity: 'error',
     reason: 'generic place holder for errors from failed `checks` evaluated from schema.',

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -249,6 +249,9 @@ export class BIDSContext implements Context {
         throw error
       }
     })
+    if (this.nifti_header && this.nifti_header.axis_codes === null) {
+      this.dataset.issues.add({ code: 'AMBIGUOUS_AFFINE', location: this.file.path })
+    }
   }
 
   async loadColumns(): Promise<void> {


### PR DESCRIPTION
Coincidentally there was an issue on nibabel (nipy/nibabel#1449) with a valid affine matrix that we wouldn't be able to handle, so along with fixing #309, I can disambiguate ambiguous affines.

Fixes #309.