### PR TITLE
fix: replace SPEC_ROOT placeholder with documentation URL

### DIFF
--- a/changelog.d/20251211_002426_guttulacharansai_fix_typo_documentation.md
+++ b/changelog.d/20251211_002426_guttulacharansai_fix_typo_documentation.md
@@ -1,0 +1,3 @@
+### Fix
+
+- Replace SPEC_ROOT placeholder with actual documentation link in CLI output

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -35,6 +35,10 @@ export function consoleFormat(
   return output.join('\n')
 }
 
+function formatMessage(text: string): string {
+  return text.replaceAll('SPEC_ROOT/', 'https://bids-specification.readthedocs.io/en/stable/')
+}
+
 function formatIssues(
   dsIssues: DatasetIssues,
   options?: LoggingOptions,
@@ -47,7 +51,8 @@ function formatIssues(
     if (issues.size === 0 || typeof code !== 'string') {
       continue
     }
-    const codeMessage = issues.codeMessages.get(code) ?? ''
+
+    const codeMessage = formatMessage(issues.codeMessages.get(code) ?? '')
     output.push(
       '\t' +
         colors[color](
@@ -92,7 +97,11 @@ function formatFiles(issues: DatasetIssues, options?: LoggingOptions): string[] 
     const fileOut: string[] = []
     issueDetails.map((key) => {
       if (Object.hasOwn(issue, key) && issue[key]) {
-        fileOut.push(`${issue[key]}`)
+        let content = `${issue[key]}`
+        if (key === 'issueMessage') {
+          content = formatMessage(content)
+        }
+        fileOut.push(content)
       }
     })
     output.push('\t\t' + fileOut.join(' - '))


### PR DESCRIPTION
**Description**
This PR addresses the issue where `SPEC_ROOT/` placeholders were being displayed in the CLI output instead of clickable links.

**Changes**
* Added a `formatMessage` helper function in `src/utils/output.ts`.
* Applied this formatting to both issue codes (`formatIssues`) and detailed issue messages (`formatFiles`).
* Links pointing to `SPEC_ROOT/` will now resolve to `https://bids-specification.readthedocs.io/en/stable/`.

**Testing**
Verified locally by simulating an issue message containing the placeholder; the output correctly rendered the full URL.