### PR TITLE
chore: Publish whatever wheels successfully build

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,6 +48,8 @@ jobs:
           - macos-15-intel
           - macos-latest
       fail-fast: false
+    continue-on-error: true
+
     permissions:
       attestations: write
       id-token: write


### PR DESCRIPTION
Deno has broken `deno compile` on macos-15-intel. They may fix it, so I'll leave the job there until they do or we give up on the platform, but if we use `continue-on-error`, we can still upload wheels for platforms that do build.

* https://github.com/denoland/deno/issues/31556