### PR TITLE
chore: Set deno version to 2.5.6 in cibuildwheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -67,7 +67,7 @@ jobs:
           rm -r dist
 
       - name: Build wheels from sdist
-        uses: pypa/cibuildwheel@v2.23
+        uses: pypa/cibuildwheel@v3.3
 
       - name: Generate artifact attestation for wheels
         if: ${{ github.event_name != 'pull_request' }}

--- a/changelog.d/20251211_102622_markiewicz_deno_2_5_6_wheels.md
+++ b/changelog.d/20251211_102622_markiewicz_deno_2_5_6_wheels.md
@@ -1,0 +1,3 @@
+### Infrastructure
+
+- Pin Deno to 2.5.6 in wheel builds to account for bugs with MacOS binaries compiled with 2.6.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ build-frontend = "build"
 manylinux-x86_64-image = "quay.io/pypa/manylinux_2_28_x86_64:latest"
 manylinux-aarch64-image = "quay.io/pypa/manylinux_2_28_aarch64:latest"
 
-before-build = "curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh && deno --version"
+before-build = "curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local deno_version=v2.5.6 sh && deno --version"
 test-command = "bids-validator-deno --version"
 
 [[tool.cibuildwheel.overrides]]


### PR DESCRIPTION
Until https://github.com/denoland/deno/issues/31556 is resolved, we will need to pin to Deno 2.5 for building macos x64 wheels. This is not great, long-term, as this will be easy to forget about and then find wheels start failing. After merging, I will create a draft pull request to un-pin that we can merge when we can.