### PR TITLE
feat: render markdown bold syntax in CLI output

### DIFF
--- a/changelog.d/20251212_121431_guttulacharansai_feat_markdown_bold.md
+++ b/changelog.d/20251212_121431_guttulacharansai_feat_markdown_bold.md
@@ -1,0 +1,3 @@
+### Feat
+
+- Render Markdown bold syntax (`**text**`) as ANSI bold in CLI output

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -36,7 +36,14 @@ export function consoleFormat(
 }
 
 function formatMessage(text: string): string {
-  return text.replaceAll('SPEC_ROOT/', 'https://bids-specification.readthedocs.io/en/stable/')
+  let formatted =  text.replaceAll('SPEC_ROOT/', 'https://bids-specification.readthedocs.io/en/stable/')
+
+  formatted = formatted.replace(/\*\*(.*?)\*\*/g, (_, match) => {
+    return colors.bold(match)
+  })
+
+  return formatted
+
 }
 
 function formatIssues(


### PR DESCRIPTION
**Description**
The validator schema often uses Markdown bold syntax (`**text**`) in issue messages, which currently renders as raw asterisks in the CLI. This PR adds support for rendering this syntax using ANSI bold codes.

**Changes**
* Updated `formatMessage` in `src/utils/output.ts` to include a Regex replacement for `**...**`.
* Uses `colors.bold()` from `@std/fmt/colors` to apply the correct ANSI formatting.

**Testing**
Verified locally by logging a test string: `formatMessage("This is **BOLD**")`. Result appeared correctly bolded in the terminal.