### PR TITLE
Revert "feat: render markdown bold syntax in CLI output"

### DIFF
--- a/changelog.d/20251212_121431_guttulacharansai_feat_markdown_bold.md
+++ b/changelog.d/20251212_121431_guttulacharansai_feat_markdown_bold.md
@@ -1,3 +1,0 @@
-### Feat
-
-- Render Markdown bold syntax (`**text**`) as ANSI bold in CLI output

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -36,14 +36,7 @@ export function consoleFormat(
 }
 
 function formatMessage(text: string): string {
-  let formatted =  text.replaceAll('SPEC_ROOT/', 'https://bids-specification.readthedocs.io/en/stable/')
-
-  formatted = formatted.replace(/\*\*(.*?)\*\*/g, (_, match) => {
-    return colors.bold(match)
-  })
-
-  return formatted
-
+  return text.replaceAll('SPEC_ROOT/', 'https://bids-specification.readthedocs.io/en/stable/')
 }
 
 function formatIssues(


### PR DESCRIPTION
Reverts bids-standard/bids-validator#318