### PR TITLE
feat: implement robust Markdown to ANSI rendering using marked

### DIFF
--- a/changelog.d/20251216_120000_charansai_markdown_rendering.md
+++ b/changelog.d/20251216_120000_charansai_markdown_rendering.md
@@ -1,3 +1,3 @@
 ### Added
 
-- Implemented robust ANSI rendering for validation messages (bold, code, links) using `marked.lexer` to improve terminal output readability.
+- Support for rendering Markdown in validation messages in the terminal.

--- a/changelog.d/20251216_120000_charansai_markdown_rendering.md
+++ b/changelog.d/20251216_120000_charansai_markdown_rendering.md
@@ -1,0 +1,3 @@
+### Feat
+
+- Implemented robust ANSI rendering for validation messages (bold, code, links) using `marked.lexer` to improve terminal output readability.

--- a/changelog.d/20251216_120000_charansai_markdown_rendering.md
+++ b/changelog.d/20251216_120000_charansai_markdown_rendering.md
@@ -1,3 +1,3 @@
-### Feat
+### Added
 
 - Implemented robust ANSI rendering for validation messages (bold, code, links) using `marked.lexer` to improve terminal output readability.

--- a/deno.json
+++ b/deno.json
@@ -44,7 +44,8 @@
     "@std/streams": "jsr:@std/streams@^1.0.14",
     "@std/yaml": "jsr:@std/yaml@^1.0.10",
     "isomorphic-git": "npm:isomorphic-git@^1.35.1",
-    "hash-wasm": "npm:hash-wasm@^4.12.0"
+    "hash-wasm": "npm:hash-wasm@^4.12.0",
+    "marked": "npm:marked@^15.0.4"
   },
   "tasks": {
     "test": "deno test -A src/"

--- a/deno.lock
+++ b/deno.lock
@@ -16,6 +16,7 @@
     "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/encoding@0.213": "0.213.1",
     "jsr:@std/encoding@^1.0.5": "1.0.5",
+    "jsr:@std/fmt@*": "1.0.8",
     "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fmt@1.0.5": "1.0.5",
     "jsr:@std/fmt@^1.0.2": "1.0.3",
@@ -43,7 +44,8 @@
     "npm:hash-wasm@^4.12.0": "4.12.0",
     "npm:hed-validator@~4.1.4": "4.1.4",
     "npm:ignore@^7.0.5": "7.0.5",
-    "npm:isomorphic-git@^1.35.1": "1.35.1"
+    "npm:isomorphic-git@^1.35.1": "1.35.1",
+    "npm:marked@*": "17.0.1"
   },
   "jsr": {
     "@bids/schema@1.1.3": {
@@ -661,6 +663,10 @@
     },
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "marked@17.0.1": {
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "bin": true
     },
     "math-intrinsics@1.1.0": {
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -51,6 +51,10 @@ function renderTokens(tokenList: any[]): string {
       return colors.bold(renderTokens(token.tokens))
     }
 
+    if (token.type === 'em') {
+      return colors.italic(renderTokens(token.tokens))
+    }
+
     if (token.type === 'codespan') {
       return colors.cyan(token.text)
     }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -4,7 +4,7 @@
 import { Table } from '@cliffy/table'
 import * as colors from '@std/fmt/colors'
 import { format as prettyBytes } from '@std/fmt/bytes'
-import { marked } from 'npm:marked'
+import { marked } from 'npm:marked@15.0.4'
 import type { SummaryOutput, ValidationResult } from '../types/validation-result.ts'
 import type { Issue, Severity } from '../types/issues.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -4,7 +4,7 @@
 import { Table } from '@cliffy/table'
 import * as colors from '@std/fmt/colors'
 import { format as prettyBytes } from '@std/fmt/bytes'
-import { marked } from 'npm:marked@15.0.4'
+import { marked } from 'marked'
 import type { SummaryOutput, ValidationResult } from '../types/validation-result.ts'
 import type { Issue, Severity } from '../types/issues.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'


### PR DESCRIPTION
### Summary
Parses and renders Markdown (bold, code, links) in validation messages for the CLI using `marked`.

### Changes
- **Refactor:** Added `renderTokens` in `src/utils/output.ts` to convert Markdown tokens to ANSI codes.
- **Dependency:** Added `npm:marked` to generate the AST.
- **Features:**
  - Renders `**bold**`, `` `code` ``, and `[links](url)`.
  - Replaces `SPEC_ROOT` placeholders with full specification URLs.
- **Safety:** Respects `--no-color` and `NO_COLOR` environment variables.

### Technical Details
Used `marked.lexer` instead of regex to correctly handle nested formatting and edge cases.

Fixes #211

### Verification
**1. Rich Text Support**

<img width="1474" height="582" alt="Screenshot from 2025-12-16 18-06-59" src="https://github.com/user-attachments/assets/dc1922a3-6d31-45af-9a3d-42226afc7b90" />


**2. No-Color Fallback**

<img width="1474" height="582" alt="Screenshot from 2025-12-16 18-07-16" src="https://github.com/user-attachments/assets/3453eeec-7da2-49d5-871d-218132157bdb" />
