### PR TITLE
rf: Stop forcing filememoize to be async

### DIFF
--- a/src/files/json.ts
+++ b/src/files/json.ts
@@ -1,4 +1,4 @@
-import { filememoizeAsync } from '../utils/memoize.ts'
+import { filememoize } from '../utils/memoize.ts'
 import type { BIDSFile } from '../types/filetree.ts'
 import { readBytes } from './access.ts'
 
@@ -39,4 +39,4 @@ async function _loadJSON(file: BIDSFile): Promise<Record<string, unknown>> {
   return parsedText
 }
 
-export const loadJSON = filememoizeAsync(_loadJSON)
+export const loadJSON = filememoize(_loadJSON)

--- a/src/files/tsv.ts
+++ b/src/files/tsv.ts
@@ -5,7 +5,7 @@
 import { TextLineStream } from '@std/streams'
 import { ColumnsMap } from '../types/columns.ts'
 import type { BIDSFile } from '../types/filetree.ts'
-import { filememoizeAsync } from '../utils/memoize.ts'
+import { filememoize } from '../utils/memoize.ts'
 import { createUTF8Stream } from './streams.ts'
 import { openStream } from './access.ts'
 import { BIDSFileDeno } from './deno.ts'
@@ -102,4 +102,4 @@ async function _loadTSV(file: BIDSFile, maxRows: number = -1): Promise<ColumnsMa
   }
 }
 
-export const loadTSV = filememoizeAsync(_loadTSV)
+export const loadTSV = filememoize(_loadTSV)

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -15,11 +15,11 @@ export const memoize = <T>(
   return cached
 }
 
-export function filememoizeAsync<F extends FileLike, T>(
-  fn: (file: F, ...args: any[]) => Promise<T>,
-): WithCache<(file: F, ...args: any[]) => Promise<T>> {
+export function filememoize<F extends FileLike, T>(
+  fn: (file: F, ...args: any[]) => T,
+): WithCache<(file: F, ...args: any[]) => T> {
   const cache = new Map<string, Map<string, T>>()
-  const cached = async function (this: any, file: F, ...args: any[]): Promise<T> {
+  const cached = function (this: any, file: F, ...args: any[]): T {
     let subcache = cache.get(file.parent.path)
     if (!subcache) {
       subcache = new Map()
@@ -28,7 +28,7 @@ export function filememoizeAsync<F extends FileLike, T>(
     const key = `${file.path}:${args.join(',')}`
     let val = subcache.get(key)
     if (!val) {
-      val = await fn.call(this, file, ...args)
+      val = fn.call(this, file, ...args)
       subcache.set(key, val)
     }
     return val


### PR DESCRIPTION
Possibly a simplification, noticed while starting to work on presigned URLs, so I'm cherry-picking this out onto a clean branch.

There's no need for memoize to be async; memoizing an async function just means the cache will contain promises instead of values, which we're rewrapping in promises anyway. I have no idea if this changes the synchronization points in any significant way, but in general it seems smart not to use async functions when pure functions will do.