### PR TITLE
fix: Use re-rooted subtree for derivative validation

### DIFF
--- a/changelog.d/20260108_164028_markiewicz_subtrees.md
+++ b/changelog.d/20260108_164028_markiewicz_subtrees.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Validate derivative file paths relative to the derivative dataset root.

--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -1,7 +1,7 @@
 import { assert, assertEquals } from '@std/assert'
 import { FileIgnoreRules } from './ignore.ts'
 import { BIDSFile, type FileOpener, type FileTree } from '../types/filetree.ts'
-import { filesToTree } from './filetree.ts'
+import { filesToTree, subtree } from './filetree.ts'
 import { StringOpener } from './openers.test.ts'
 
 export function pathToFile(path: string, ignored: boolean = false): BIDSFile {
@@ -75,5 +75,34 @@ Deno.test('FileTree generation', async (t) => {
     ])
     const bad_file = tree.get('bad_file') as BIDSFile
     assert(bad_file.ignored)
+  })
+})
+
+Deno.test('extract subtrees', async (t) => {
+  await t.step('Successfully re-roots derivatives', async () => {
+    const tree = pathsToTree([
+      '/dataset_description.json',
+      '/sub-01/anat/sub-01_T1w.nii.gz',
+      '/derivatives/pipeline/dataset_description.json',
+      '/derivatives/pipeline/sub-01/anat/sub-01_desc-preproc_T1w.nii.gz',
+    ])
+    assertEquals(tree.directories.map((d) => d.name), ['sub-01', 'derivatives'])
+    assertEquals(tree.files.map((f) => f.name), ['dataset_description.json'])
+
+    const pipeline = tree.get('derivatives/pipeline') as FileTree
+    assertEquals(pipeline.path, '/derivatives/pipeline')
+    assertEquals(pipeline.directories.map((d) => d.path), ['/derivatives/pipeline/sub-01'])
+    assertEquals(pipeline.files.map((f) => f.path), [
+      '/derivatives/pipeline/dataset_description.json',
+    ])
+
+    const derivTree = await subtree(pipeline)
+    assertEquals(derivTree.path, '/')
+    assertEquals(derivTree.directories.map((d) => d.path), ['/sub-01'])
+    assertEquals(derivTree.files.map((f) => f.path), ['/dataset_description.json'])
+    assertEquals(
+      derivTree.get('sub-01/anat/sub-01_desc-preproc_T1w.nii.gz')!.path,
+      '/sub-01/anat/sub-01_desc-preproc_T1w.nii.gz',
+    )
   })
 })

--- a/src/files/filetree.ts
+++ b/src/files/filetree.ts
@@ -45,7 +45,7 @@ function rerootTree({
 }: RerootTreeOptions): FileTree {
   const tree = new FileTree(
     oldTree.path.substr(newRoot.length) || '/',
-    parent ? oldTree.name : '/',
+    parent ? oldTree.name : `${oldTree.path}/`,  // Set the name of the root to its full path
     parent,
     ignore,
   )

--- a/src/files/filetree.ts
+++ b/src/files/filetree.ts
@@ -1,7 +1,7 @@
 import { parse, SEPARATOR_PATTERN } from '@std/path'
 import * as posix from '@std/path/posix'
 import { BIDSFile, FileTree } from '../types/filetree.ts'
-import { FileIgnoreRules } from './ignore.ts'
+import { FileIgnoreRules, readBidsIgnore } from './ignore.ts'
 
 export function filesToTree(fileList: BIDSFile[], ignore?: FileIgnoreRules): FileTree {
   ignore = ignore ?? new FileIgnoreRules([])
@@ -26,6 +26,48 @@ export function filesToTree(fileList: BIDSFile[], ignore?: FileIgnoreRules): Fil
     }
     current.files.push(file)
     file.parent = current
+  }
+  return tree
+}
+
+type RerootTreeOptions = {
+  oldTree: FileTree
+  newRoot: string
+  ignore: FileIgnoreRules
+  parent?: FileTree
+}
+
+function rerootTree({
+  oldTree,
+  newRoot,
+  ignore,
+  parent,
+}: RerootTreeOptions): FileTree {
+  const tree = new FileTree(
+    oldTree.path.substr(newRoot.length) || '/',
+    parent ? oldTree.name : '/',
+    parent,
+    ignore,
+  )
+  tree.files = oldTree.files.map((file) =>
+    new BIDSFile(file.path.substr(newRoot.length), file.opener, ignore, tree)
+  )
+  tree.directories = oldTree.directories.map((dir) =>
+    rerootTree({ oldTree: dir, newRoot, ignore, parent: tree })
+  )
+  return tree
+}
+
+export async function subtree(filetree: FileTree): Promise<FileTree> {
+  const ignore = new FileIgnoreRules([])
+  const tree = rerootTree({oldTree: filetree, newRoot: filetree.path, ignore})
+  const bidsignore = tree.get('.bidsignore')
+  if (bidsignore) {
+    try {
+      ignore.add(await readBidsIgnore(bidsignore as BIDSFile))
+    } catch (err) {
+      console.log(`Failed to read '.bidsignore' file with the following error:\n${err}`)
+    }
   }
   return tree
 }


### PR DESCRIPTION
@bendhouseart noted that recursive validation fails (despite #323) because the file paths are relative to the top-level dataset root. This adds a function to re-root a subtree, and we will use that. It also drops the top-level `.bidsignore` and loads the sub-dataset's `.bidsignore`, if present.