### PR TITLE
Normalize error handling for HTTPOpener, add tests for it as well.

### DIFF
--- a/changelog.d/20260112_152523_rosswilsonblair.md
+++ b/changelog.d/20260112_152523_rosswilsonblair.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- Have all three calls to fetch in HttpOpener use same error handling.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/deno.json
+++ b/deno.json
@@ -42,6 +42,7 @@
     "@std/log": "jsr:@std/log@^0.224.14",
     "@std/path": "jsr:@std/path@^1.1.3",
     "@std/streams": "jsr:@std/streams@^1.0.14",
+    "@std/testing": "jsr:@std/testing@^1.0.16",
     "@std/yaml": "jsr:@std/yaml@^1.0.10",
     "isomorphic-git": "npm:isomorphic-git@^1.35.1",
     "hash-wasm": "npm:hash-wasm@^4.12.0",

--- a/deno.lock
+++ b/deno.lock
@@ -9,11 +9,13 @@
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@libs/xml@^7.0.3": "7.0.3",
+    "jsr:@std/assert@^1.0.15": "1.0.16",
     "jsr:@std/assert@^1.0.16": "1.0.16",
     "jsr:@std/assert@~0.213.1": "0.213.1",
     "jsr:@std/bytes@^1.0.2-rc.3": "1.0.2",
     "jsr:@std/bytes@^1.0.5": "1.0.6",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/data-structures@^1.0.9": "1.0.9",
     "jsr:@std/encoding@0.213": "0.213.1",
     "jsr:@std/encoding@^1.0.5": "1.0.5",
     "jsr:@std/fmt@*": "1.0.8",
@@ -24,6 +26,7 @@
     "jsr:@std/fmt@^1.0.8": "1.0.8",
     "jsr:@std/fmt@~1.0.2": "1.0.8",
     "jsr:@std/fs@^1.0.11": "1.0.20",
+    "jsr:@std/fs@^1.0.19": "1.0.20",
     "jsr:@std/fs@^1.0.20": "1.0.20",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/io@~0.225.2": "0.225.2",
@@ -31,8 +34,10 @@
     "jsr:@std/log@~0.224.14": "0.224.14",
     "jsr:@std/path@0.213": "0.213.1",
     "jsr:@std/path@^1.0.6": "1.0.6",
+    "jsr:@std/path@^1.1.2": "1.1.3",
     "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/streams@^1.0.14": "1.0.14",
+    "jsr:@std/testing@^1.0.16": "1.0.16",
     "jsr:@std/text@~1.0.7": "1.0.16",
     "jsr:@std/yaml@^1.0.10": "1.0.10",
     "npm:@bids/nifti-reader-js@~0.6.9": "0.6.9",
@@ -45,7 +50,8 @@
     "npm:hed-validator@~4.1.4": "4.1.4",
     "npm:ignore@^7.0.5": "7.0.5",
     "npm:isomorphic-git@^1.35.1": "1.35.1",
-    "npm:marked@*": "17.0.1"
+    "npm:marked@*": "17.0.1",
+    "npm:marked@^15.0.4": "15.0.12"
   },
   "jsr": {
     "@bids/schema@1.1.3": {
@@ -106,6 +112,9 @@
     },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
+    "@std/data-structures@1.0.9": {
+      "integrity": "033d6e17e64bf1f84a614e647c1b015fa2576ae3312305821e1a4cb20674bb4d"
     },
     "@std/encoding@0.213.1": {
       "integrity": "fcbb6928713dde941a18ca5db88ca1544d0755ec8fb20fe61e2dc8144b390c62"
@@ -177,6 +186,16 @@
       "integrity": "c0df6cdd73bd4bbcbe4baa89e323b88418c90ceb2d926f95aa99bdcdbfca2411",
       "dependencies": [
         "jsr:@std/bytes@^1.0.6"
+      ]
+    },
+    "@std/testing@1.0.16": {
+      "integrity": "a917ffdeb5924c9be436dc78bc32e511760e14d3a96e49c607fc5ecca86d0092",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.15",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.19",
+        "jsr:@std/internal",
+        "jsr:@std/path@^1.1.2"
       ]
     },
     "@std/text@1.0.8": {
@@ -664,6 +683,10 @@
     "lodash@4.17.21": {
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "marked@15.0.12": {
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "bin": true
+    },
     "marked@17.0.1": {
       "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
       "bin": true
@@ -1128,6 +1151,7 @@
       "jsr:@std/log@~0.224.14",
       "jsr:@std/path@^1.1.3",
       "jsr:@std/streams@^1.0.14",
+      "jsr:@std/testing@^1.0.16",
       "jsr:@std/yaml@^1.0.10",
       "npm:@bids/nifti-reader-js@~0.6.9",
       "npm:ajv@^8.17.1",


### PR DESCRIPTION
While reviewing #333 I noticed only 1 of the three HTTPOpener openers would throw an error if the resource was unavailable.