### PR TITLE
fix: Add memoize resolver option and default to serialization of all arguments

### DIFF
--- a/changelog.d/20260113_101504_nell_memoize_fixes.md
+++ b/changelog.d/20260113_101504_nell_memoize_fixes.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- Fix memoization memory leak for readRemotes.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/files/repo.ts
+++ b/src/files/repo.ts
@@ -157,7 +157,7 @@ async function _readRemotes(options: any): Promise<Record<string, Record<string,
   return byUUID
 }
 
-const readRemotes = memoize(_readRemotes)
+const readRemotes = memoize(_readRemotes, (options) => options?.gitdir)
 
 export async function parseAnnexedFile(
   path: string,

--- a/src/schema/datatypes.ts
+++ b/src/schema/datatypes.ts
@@ -14,7 +14,7 @@ function _modalityTable(schema: Schema): Record<string, string> {
 }
 
 // Construct once per schema; should only be multiple in tests
-export const modalityTable = memoize(_modalityTable)
+export const modalityTable = memoize(_modalityTable, (schema) => schema)
 
 export function findDatatype(
   file: BIDSFile,

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -6,10 +6,11 @@ interface FileLike {
 
 export const memoize = <T>(
   fn: (...args: any[]) => T,
+  resolver?: (...args: any[]) => any,
 ): WithCache<(...args: any[]) => T> => {
   const cache = new Map()
   const cached = function (this: any, ...args: any[]) {
-    const key = JSON.stringify(args)
+    const key = resolver ? resolver(...args) : JSON.stringify(args)
     return cache.has(key) ? cache.get(key) : cache.set(key, fn.apply(this, args)) && cache.get(key)
   }
   cached.cache = cache

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -1,4 +1,4 @@
-export type WithCache<T> = T & { cache: Map<string, any> }
+export type WithCache<T> = T & { cache: Map<any, any> }
 interface FileLike {
   path: string
   parent: { path: string }
@@ -8,8 +8,9 @@ export const memoize = <T>(
   fn: (...args: any[]) => T,
 ): WithCache<(...args: any[]) => T> => {
   const cache = new Map()
-  const cached = function (this: any, val: T) {
-    return cache.has(val) ? cache.get(val) : cache.set(val, fn.call(this, val)) && cache.get(val)
+  const cached = function (this: any, ...args: any[]) {
+    const key = JSON.stringify(args)
+    return cache.has(key) ? cache.get(key) : cache.set(key, fn.apply(this, args)) && cache.get(key)
   }
   cached.cache = cache
   return cached


### PR DESCRIPTION
While reviewing #333 I ran into a memory leak where dangling references to the packfile object references were held by memoize cache keys. Avoiding using these objects as keys prevents the memory leak but it's probably safer to serialize by default and except anything where this is an issue. The resolver function can be used in any case where memoization should be a partial key of the arguments.

Limits the memoize key to the repo path for readRemotes to avoid serializing the full options object. This is also done for modalityTable to use the object as the key to skip serialization in that case as it is stable.