### PR TITLE
Fix/339 bug update exit code if recursed directory contains errors

### DIFF
--- a/changelog.d/20260116_093212_28850131+bendhouseart_339_bug_update_exit_code_if_recursed_directory_contains_errors.md
+++ b/changelog.d/20260116_093212_28850131+bendhouseart_339_bug_update_exit_code_if_recursed_directory_contains_errors.md
@@ -1,0 +1,48 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- exit code returns non-zero status for invalid derivative datasets
+when -r/--recursive flag is used
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/changelog.d/20260116_093212_28850131+bendhouseart_339_bug_update_exit_code_if_recursed_directory_contains_errors.md
+++ b/changelog.d/20260116_093212_28850131+bendhouseart_339_bug_update_exit_code_if_recursed_directory_contains_errors.md
@@ -18,10 +18,8 @@ Uncomment the section that is right (remove the HTML comment wrapper).
 -->
 ### Fixed
 
-- exit code returns non-zero status for invalid derivative datasets
-when -r/--recursive flag is used
+- Exit with a non-zero exit code if nested datasets are validated and found to have errors.
 
--->
 <!--
 ### Deprecated
 

--- a/local-test
+++ b/local-test
@@ -1,0 +1,4 @@
+#!/usr/bin/env -S deno test --allow-read --allow-write --allow-env --allow-run --allow-net --parallel --node-modules-dir=auto  --coverage=cov/ src/ 
+// This script runs the local copy of the validator, intended as a development aid.
+// You generally should run `deno run -A jsr:@bids/validator`
+`deno test --allow-read --allow-write --allow-env --allow-run --allow-net --parallel --node-modules-dir=auto  --coverage=cov/ src/`

--- a/local-test
+++ b/local-test
@@ -1,2 +1,3 @@
+#!/bin/sh
 # script to run tests locally and save some CI time
-`deno test --allow-read --allow-write --allow-env --allow-run --allow-net --parallel --node-modules-dir=auto  --coverage=cov/ src/`
+deno test --allow-read --allow-write --allow-env --allow-run --allow-net --parallel --node-modules-dir=auto  --coverage=cov/ src/

--- a/local-test
+++ b/local-test
@@ -1,4 +1,2 @@
-#!/usr/bin/env -S deno test --allow-read --allow-write --allow-env --allow-run --allow-net --parallel --node-modules-dir=auto  --coverage=cov/ src/ 
-// This script runs the local copy of the validator, intended as a development aid.
-// You generally should run `deno run -A jsr:@bids/validator`
+# script to run tests locally and save some CI time
 `deno test --allow-read --allow-write --allow-env --allow-run --allow-net --parallel --node-modules-dir=auto  --coverage=cov/ src/`

--- a/src/bids-validator.ts
+++ b/src/bids-validator.ts
@@ -1,8 +1,11 @@
 import { main } from './main.ts'
+import { checkAllErrors } from './summary/summary.ts'
 
 const result = await main()
+// write result to formated json file in current working directory named result_dataset_folder.json
+console.log(result.summary)
+const errors = checkAllErrors(result)
 
-const errors = result.issues.get({ severity: 'error' })
 if (errors.length) {
   Deno.exit(16)
 }

--- a/src/bids-validator.ts
+++ b/src/bids-validator.ts
@@ -1,10 +1,9 @@
 import { main } from './main.ts'
-import { checkAllErrors } from './summary/summary.ts'
+import { detectErrors } from './summary/summary.ts'
 
 const result = await main()
-const errors = checkAllErrors(result)
 
-if (errors.length) {
+if (detectErrors(result)) {
   Deno.exit(16)
 }
 Deno.exit(0)

--- a/src/bids-validator.ts
+++ b/src/bids-validator.ts
@@ -2,8 +2,6 @@ import { main } from './main.ts'
 import { checkAllErrors } from './summary/summary.ts'
 
 const result = await main()
-// write result to formated json file in current working directory named result_dataset_folder.json
-console.log(result.summary)
 const errors = checkAllErrors(result)
 
 if (errors.length) {

--- a/src/summary/summary.test.ts
+++ b/src/summary/summary.test.ts
@@ -1,5 +1,9 @@
 import { computeModalities, modalityPrettyLookup, Summary } from './summary.ts'
 import { assertEquals, type assertObjectMatch } from '@std/assert'
+import { checkAllErrors } from './summary.ts'
+import { ValidationResult } from '../types/validation-result.ts'
+import { DatasetIssues } from '../issues/datasetIssues.ts'
+import type { Issue } from '../types/issues.ts'
 
 Deno.test('Summary class and helper functions', async (t) => {
   await t.step('Constructor succeeds', () => {
@@ -13,3 +17,109 @@ Deno.test('Summary class and helper functions', async (t) => {
     assertEquals(computeModalities(modalitiesIn), modalitiesOut)
   })
 })
+
+const json_mock_validation_result = {
+  "issues": {
+    "issues": [],
+    "codeMessages": {}
+  },
+  "summary": {
+    "sessions": [],
+    "subjects": [
+      "01"
+    ],
+    "subjectMetadata": [],
+    "tasks": [],
+    "modalities": [
+      "MRI"
+    ],
+    "secondaryModalities": [
+      "MRI_Structural"
+    ],
+    "totalFiles": 14,
+    "size": 1513,
+    "dataProcessed": false,
+    "pet": {},
+    "dataTypes": [
+      "fmap",
+      "anat"
+    ],
+    "schemaVersion": "1.1.3"
+  },
+  "derivativesSummary": {
+    "/derivatives/qMRLab/": {
+      "issues": {
+        "issues": [
+          {
+            "code": "EMPTY_FILE",
+            "severity": "error",
+            "location": "/README"
+          },
+        ]
+      },
+      "summary": {
+        "sessions": [],
+        "subjects": [
+          "01"
+        ],
+        "subjectMetadata": [],
+        "tasks": [],
+        "modalities": [
+          "MRI"
+        ],
+        "secondaryModalities": [
+          "MRI_Structural"
+        ],
+        "totalFiles": 12,
+        "size": 3715,
+        "dataProcessed": true,
+        "pet": {},
+        "dataTypes": [
+          "fmap",
+          "anat"
+        ],
+        "schemaVersion": "1.1.3"
+      }
+    }
+  }
+}
+
+const mockValidationResultBadDerivatives: ValidationResult = {
+  issues: new DatasetIssues({ 
+    issues: json_mock_validation_result.issues.issues as Issue[],
+    codeMessages: new Map(Object.entries(json_mock_validation_result.issues.codeMessages)),
+    }),
+  summary: json_mock_validation_result.summary,
+  derivativesSummary: {
+    "/derivatives/mock/": {
+      issues: new DatasetIssues({
+        issues: json_mock_validation_result.derivativesSummary["/derivatives/qMRLab/"].issues.issues as Issue[],
+      }),
+      summary: json_mock_validation_result.derivativesSummary["/derivatives/qMRLab/"].summary,
+    }
+  }
+}
+
+const mockValidationResultBadRawData: ValidationResult = {
+  issues: new DatasetIssues({ 
+    issues: json_mock_validation_result.derivativesSummary["/derivatives/qMRLab/"].issues.issues as Issue[],
+    }),
+  summary: json_mock_validation_result.summary,
+}
+
+Deno.test('checkAllErrors properly collects errors', () => {
+  const errors = checkAllErrors(mockValidationResultBadDerivatives)
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].code, 'EMPTY_FILE')
+  assertEquals(errors[0].severity, 'error')
+  assertEquals(errors[0].location, '/README')
+})
+
+Deno.test('checkAllErrors properly collects errors from raw data', () => {
+  const errors = checkAllErrors(mockValidationResultBadRawData)
+  assertEquals(errors.length, 1)
+  assertEquals(errors[0].code, 'EMPTY_FILE')
+  assertEquals(errors[0].severity, 'error')
+  assertEquals(errors[0].location, '/README')
+  }
+)

--- a/src/summary/summary.test.ts
+++ b/src/summary/summary.test.ts
@@ -47,7 +47,7 @@ const json_mock_validation_result = {
     "schemaVersion": "1.1.3"
   },
   "derivativesSummary": {
-    "/derivatives/qMRLab/": {
+    "/derivatives/mock/": {
       "issues": {
         "issues": [
           {
@@ -93,16 +93,16 @@ const mockValidationResultBadDerivatives: ValidationResult = {
   derivativesSummary: {
     "/derivatives/mock/": {
       issues: new DatasetIssues({
-        issues: json_mock_validation_result.derivativesSummary["/derivatives/qMRLab/"].issues.issues as Issue[],
+        issues: json_mock_validation_result.derivativesSummary["/derivatives/mock/"].issues.issues as Issue[],
       }),
-      summary: json_mock_validation_result.derivativesSummary["/derivatives/qMRLab/"].summary,
+      summary: json_mock_validation_result.derivativesSummary["/derivatives/mock/"].summary,
     }
   }
 }
 
 const mockValidationResultBadRawData: ValidationResult = {
   issues: new DatasetIssues({ 
-    issues: json_mock_validation_result.derivativesSummary["/derivatives/qMRLab/"].issues.issues as Issue[],
+    issues: json_mock_validation_result.derivativesSummary["/derivatives/mock/"].issues.issues as Issue[],
     }),
   summary: json_mock_validation_result.summary,
 }

--- a/src/summary/summary.test.ts
+++ b/src/summary/summary.test.ts
@@ -1,6 +1,6 @@
 import { computeModalities, modalityPrettyLookup, Summary } from './summary.ts'
 import { assertEquals, type assertObjectMatch } from '@std/assert'
-import { checkAllErrors } from './summary.ts'
+import { detectErrors } from './summary.ts'
 import { ValidationResult } from '../types/validation-result.ts'
 import { DatasetIssues } from '../issues/datasetIssues.ts'
 import type { Issue } from '../types/issues.ts'
@@ -107,20 +107,14 @@ const mockValidationResultBadRawData: ValidationResult = {
   summary: json_mock_validation_result.summary,
 }
 
-Deno.test('checkAllErrors properly collects errors', () => {
-  const errors = checkAllErrors(mockValidationResultBadDerivatives)
-  assertEquals(errors.length, 1)
-  assertEquals(errors[0].code, 'EMPTY_FILE')
-  assertEquals(errors[0].severity, 'error')
-  assertEquals(errors[0].location, '/README')
+Deno.test('detectErrors properly collects errors', () => {
+  const errors = detectErrors(mockValidationResultBadDerivatives)
+  assertEquals(errors, true)
 })
 
-Deno.test('checkAllErrors properly collects errors from raw data', () => {
-  const errors = checkAllErrors(mockValidationResultBadRawData)
-  assertEquals(errors.length, 1)
-  assertEquals(errors[0].code, 'EMPTY_FILE')
-  assertEquals(errors[0].severity, 'error')
-  assertEquals(errors[0].location, '/README')
+Deno.test('detectErrors properly collects errors from raw data', () => {
+  const errors = detectErrors(mockValidationResultBadRawData)
+  assertEquals(errors, true)
 })
 
 const mockValidationResultNoErrors: ValidationResult = {
@@ -140,7 +134,7 @@ const mockValidationResultNoErrors: ValidationResult = {
   }
 }
 
-Deno.test('checkAllErrors returns empty array when no errors found', () => {
-  const errors = checkAllErrors(mockValidationResultNoErrors)
-  assertEquals(errors.length, 0)
+Deno.test('detectErrors returns false when no errors found', () => {
+  const errors = detectErrors(mockValidationResultNoErrors)
+  assertEquals(errors, false)
 })

--- a/src/summary/summary.test.ts
+++ b/src/summary/summary.test.ts
@@ -121,5 +121,26 @@ Deno.test('checkAllErrors properly collects errors from raw data', () => {
   assertEquals(errors[0].code, 'EMPTY_FILE')
   assertEquals(errors[0].severity, 'error')
   assertEquals(errors[0].location, '/README')
+})
+
+const mockValidationResultNoErrors: ValidationResult = {
+  issues: new DatasetIssues({
+    issues: [],
+    codeMessages: new Map(),
+  }),
+  summary: json_mock_validation_result.summary,
+  derivativesSummary: {
+    "/derivatives/mock/": {
+      issues: new DatasetIssues({
+        issues: [],
+        codeMessages: new Map(),
+      }),
+      summary: json_mock_validation_result.derivativesSummary["/derivatives/mock/"].summary,
+    }
   }
-)
+}
+
+Deno.test('checkAllErrors returns empty array when no errors found', () => {
+  const errors = checkAllErrors(mockValidationResultNoErrors)
+  assertEquals(errors.length, 0)
+})

--- a/src/summary/summary.ts
+++ b/src/summary/summary.ts
@@ -172,23 +172,7 @@ export class Summary {
   }
 }
 
-export function checkAllErrors(result: ValidationResult): Issue[] {
-  const errors: Issue[] = []
-
-  for (const key in result) {
-    if (key == "issues") {
-      errors.push(...result[key].get({ severity: 'error' }))
-      if (errors.length > 0) {
-        return errors
-      }
-    } else if (key == "derivativesSummary") {
-      for (const derivative in result[key]) {
-        errors.push(...checkAllErrors(result[key][derivative]))
-        if (errors.length > 0) {
-          return errors
-        }
-      }
-    }
-  }
-  return errors
+export function detectErrors(result: ValidationResult): boolean {
+  return result.issues.get({ severity: 'error' }).length > 0 ||
+    Object.values(result.derivativesSummary ?? {}).some((res) => detectErrors(res))
 }

--- a/src/summary/summary.ts
+++ b/src/summary/summary.ts
@@ -178,9 +178,15 @@ export function checkAllErrors(result: ValidationResult): Issue[] {
   for (const key in result) {
     if (key == "issues") {
       errors.push(...result[key].get({ severity: 'error' }))
+      if (errors.length > 0) {
+        return errors
+      }
     } else if (key == "derivativesSummary") {
       for (const derivative in result[key]) {
         errors.push(...checkAllErrors(result[key][derivative]))
+        if (errors.length > 0) {
+          return errors
+        }
       }
     }
   }

--- a/src/summary/summary.ts
+++ b/src/summary/summary.ts
@@ -1,6 +1,8 @@
 import { collectSubjectMetadata } from './collectSubjectMetadata.ts'
 import type { SubjectMetadata, SummaryOutput } from '../types/validation-result.ts'
 import type { BIDSContext } from '../schema/context.ts'
+import type { ValidationResult } from '../types/validation-result.ts'
+import type { Issue } from '../types/issues.ts'
 
 export const modalityPrettyLookup: Record<string, string> = {
   mri: 'MRI',
@@ -168,4 +170,19 @@ export class Summary {
       schemaVersion: this.schemaVersion,
     }
   }
+}
+
+export function checkAllErrors(result: ValidationResult): Issue[] {
+  const errors: Issue[] = []
+
+  for (const key in result) {
+    if (key == "issues") {
+      errors.push(...result[key].get({ severity: 'error' }))
+    } else if (key == "derivativesSummary") {
+      for (const derivative in result[key]) {
+        errors.push(...checkAllErrors(result[key][derivative]))
+      }
+    }
+  }
+  return errors
 }


### PR DESCRIPTION
A nested/derivatives bids dataset returns a 0 exit code even if it's evaluated as invalid, this PR sets the exit code to non-zero in that case. 