### PR TITLE
feat: Memoize readBytes/readText to avoid excess fetches

### DIFF
--- a/changelog.d/20260129_153305_markiewicz_memoize_read.md
+++ b/changelog.d/20260129_153305_markiewicz_memoize_read.md
@@ -1,0 +1,3 @@
+### Changed
+
+- File reads are temporarily cached to avoid multiple fetches/opens.

--- a/deno.lock
+++ b/deno.lock
@@ -6,6 +6,8 @@
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
+    "jsr:@deno/esbuild-plugin@1.1.5": "1.1.5",
+    "jsr:@deno/loader@~0.3.3": "0.3.11",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
@@ -24,6 +26,7 @@
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/io@~0.225.2": "0.225.2",
     "jsr:@std/log@~0.224.14": "0.224.14",
+    "jsr:@std/path@^1.1.1": "1.1.4",
     "jsr:@std/path@^1.1.2": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/streams@^1.0.16": "1.0.16",
@@ -62,6 +65,16 @@
       "dependencies": [
         "jsr:@std/fmt@~1.0.2"
       ]
+    },
+    "@deno/esbuild-plugin@1.1.5": {
+      "integrity": "c9cde95990b97802a0da6c73c26ab4a48f30d286818845e365dddcd8297abd7d",
+      "dependencies": [
+        "jsr:@deno/loader",
+        "jsr:@std/path@^1.1.1"
+      ]
+    },
+    "@deno/loader@0.3.11": {
+      "integrity": "7c62f4f09cdfc34e66ba25b5a775a1830cbb5266b3e39f67b0f620c75484df8d"
     },
     "@effigies/cliffy-command@1.0.0-dev.8": {
       "integrity": "d6489c66bf7f603225a426b26b62eaee32bf6da04b69056bcb015a1f17190087",

--- a/src/files/access.ts
+++ b/src/files/access.ts
@@ -3,7 +3,6 @@ import { type Issue } from '../types/issues.ts'
 import { filememoize } from '../utils/memoize.ts'
 
 function IOErrorToIssue(err: { code: string; name: string }): Issue {
-  const subcode = err.name
   let issueMessage: string | undefined = undefined
   if (err.code === 'ENOENT' || err.code === 'ELOOP') {
     issueMessage = 'Possible dangling symbolic link'

--- a/src/files/access.ts
+++ b/src/files/access.ts
@@ -1,5 +1,6 @@
 import { type BIDSFile } from '../types/filetree.ts'
 import { type Issue } from '../types/issues.ts'
+import { filememoize } from '../utils/memoize.ts'
 
 function IOErrorToIssue(err: { code: string; name: string }): Issue {
   const subcode = err.name
@@ -18,7 +19,7 @@ export async function openStream(
   })
 }
 
-export async function readBytes(
+async function _readBytes(
   file: BIDSFile,
   size: number,
   offset = 0,
@@ -28,8 +29,12 @@ export async function readBytes(
   })
 }
 
-export async function readText(file: BIDSFile): Promise<string> {
+export const readBytes = filememoize(_readBytes)
+
+async function _readText(file: BIDSFile): Promise<string> {
   return file.text().catch((err: any) => {
     throw { location: file.path, ...IOErrorToIssue(err) }
   })
 }
+
+export const readText = filememoize(_readText)

--- a/src/files/gzip.ts
+++ b/src/files/gzip.ts
@@ -18,7 +18,7 @@ import { readBytes } from './access.ts'
  */
 export async function parseGzip(
   file: BIDSFile,
-  maxBytes: number = 512,
+  maxBytes: number = 1024,
 ): Promise<Gzip | undefined> {
   const buf = await readBytes(file, maxBytes)
   const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength)

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -317,7 +317,7 @@ export class BIDSContext implements Context {
     if (!this.extension.endsWith('.gz')) {
       return
     }
-    this.gzip = await parseGzip(this.file, 512).catch((error) => {
+    this.gzip = await parseGzip(this.file, 1024).catch((error) => {
       logger.debug('Error parsing gzip header', error)
       return undefined
     })

--- a/src/schema/walk.ts
+++ b/src/schema/walk.ts
@@ -4,6 +4,7 @@ import type { DatasetIssues } from '../issues/datasetIssues.ts'
 import { NullFileOpener } from '../files/openers.ts'
 import { loadTSV } from '../files/tsv.ts'
 import { loadJSON } from '../files/json.ts'
+import { readBytes, readText } from '../files/access.ts'
 import { queuedAsyncIterator } from '../utils/queue.ts'
 
 function* quickWalk(dir: FileTree): Generator<BIDSFile> {
@@ -54,6 +55,8 @@ async function* _walkFileTree(
   yield () => {
     loadTSV.cache.delete(fileTree.path)
     loadJSON.cache.delete(fileTree.path)
+    readBytes.cache.delete(fileTree.path)
+    readText.cache.delete(fileTree.path)
   }
 }
 

--- a/src/utils/memoize.ts
+++ b/src/utils/memoize.ts
@@ -17,11 +17,11 @@ export const memoize = <A extends any[], R>(
   return cached
 }
 
-export function filememoize<F extends FileLike, T>(
-  fn: (file: F, ...args: any[]) => T,
-): WithCache<(file: F, ...args: any[]) => T> {
-  const cache = new Map<string, Map<string, T>>()
-  const cached = function (this: any, file: F, ...args: any[]): T {
+export function filememoize<F extends FileLike, A extends any[], R>(
+  fn: (file: F, ...args: A) => R,
+): WithCache<(file: F, ...args: A) => R> {
+  const cache = new Map<string, Map<string, R>>()
+  const cached = function (this: any, file: F, ...args: A): R {
     let subcache = cache.get(file.parent.path)
     if (!subcache) {
       subcache = new Map()


### PR DESCRIPTION
This treats them the same as `loadTSV` and `loadJSON`.

This PR also updates the type signature for filememoize a la #337.

Closes #348.