### PR TITLE
fix: Skip directory match for unknown DatasetType

### DIFF
--- a/changelog.d/20260209_152321_markiewicz_sanitize_datasettype.md
+++ b/changelog.d/20260209_152321_markiewicz_sanitize_datasettype.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Validating directory names is now skipped for unknown `DatasetType`s in
+  `dataset_description.json`. Previously this would crash, preventing the error
+  in `DatasetType` values from being reported to the user.

--- a/src/validators/filenameIdentify.test.ts
+++ b/src/validators/filenameIdentify.test.ts
@@ -111,4 +111,13 @@ Deno.test('test directoryIdentify', async (t) => {
     assertEquals(context.filenameRules.length, 1)
     assertEquals(context.filenameRules[0], 'rules.directories.raw.datatype')
   })
+  await t.step('Test unknown DatasetType', async () => {
+    const fileName = '/func/'
+    const file = new BIDSFileDeno(`${PATH}/sub-01/ses-01`, fileName, ignore)
+    const context = await makeBIDSContext(file)
+    context.directory = true
+    context.dataset.dataset_description.DatasetType = 'unknown'
+    await findDirRuleMatches(schema, context)
+    assertEquals(context.filenameRules.length, 0)
+  })
 })

--- a/src/validators/filenameIdentify.ts
+++ b/src/validators/filenameIdentify.ts
@@ -40,7 +40,7 @@ export async function filenameIdentify(schema, context) {
 export async function findDirRuleMatches(schema, context) {
   const datasetType = context.dataset.dataset_description?.DatasetType || 'raw'
   const schemaPath = `rules.directories.${datasetType}`
-  const directoryRule = schema[schemaPath]
+  const directoryRule = schema[schemaPath] ?? {}
   const schemaObjects = schema['objects']
   const schemaEntities = schema['objects.entities']
   loop: for (const key of Object.keys(directoryRule)) {


### PR DESCRIPTION
Validating directory names is now skipped for unknown `DatasetType`s in `dataset_description.json`. Previously this would crash, preventing the error in `DatasetType` values from being reported to the user.

Closes: None.

Discovered when investigating a hanging validation on OpenNeuro.