### PR TITLE
Hardcode abs path to bids-validator.js for ENTRYPOINT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ FROM ${BASE_IMAGE} AS min
 WORKDIR /src
 COPY --from=build /src/dist/validator/bids-validator.js .
 
-ENTRYPOINT ["deno", "-A", "./bids-validator.js"]
+ENTRYPOINT ["deno", "-A", "/src/bids-validator.js"]

--- a/changelog.d/20260407_165331_yarikoptic_bf_entrypoint_path.md
+++ b/changelog.d/20260407_165331_yarikoptic_bf_entrypoint_path.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Use absolute path to .js within Dockerfile ENTRYPOINT,
+  so could be found by singularity execution from arbitrary
+  working directory


### PR DESCRIPTION
that should allow for singularity to run such a container where its workdir differs from hardcoded in Dockerfile for docker `/src`

- addresses part of #373 , the other part might be worked around by pointing ` DENO_DIR=/tmp/deno` or alike (better uses mktemp!), but it is somewhat orthogonal here