### PR TITLE
doc: Improve API documentation

### DIFF
--- a/changelog.d/20260410_101644_markiewicz_library_api.md
+++ b/changelog.d/20260410_101644_markiewicz_library_api.md
@@ -1,0 +1,4 @@
+### Added
+
+- Documented the library API: added a usage guide under `docs/dev/using-the-api.md`,
+  JSDoc on `validate()`, and JSDoc with `@throws` on `DatasetIssues.add()`.

--- a/docs/dev/using-the-api.md
+++ b/docs/dev/using-the-api.md
@@ -43,9 +43,17 @@ console.log(`${result.issues.size} issues found`)
 console.log(`Validated against schema ${result.summary.schemaVersion}`)
 ```
 
-`readFileTree` requires read access to the dataset directory; run the
-program with `deno run -R=/path/to/dataset script.ts` (or `-ERWN` for
-the same set of permissions used by the published CLI).
+`readFileTree` requires read access to the dataset directory. In
+practice the validator also reads the `BIDS_SCHEMA` environment
+variable and may fetch a schema over the network, so the simplest
+approach is to use the same permission set as the published CLI:
+
+```sh
+deno run -ERWN script.ts
+```
+
+If you want tighter scoping, grant only what the validator actually
+needs: `-R=/path/to/dataset -E=BIDS_SCHEMA -W=/path/to/dataset -N=bids-specification.readthedocs.io`.
 
 ## Working with the result
 

--- a/docs/dev/using-the-api.md
+++ b/docs/dev/using-the-api.md
@@ -1,1 +1,123 @@
 # Using the API
+
+The BIDS Validator can be used as a library from Deno, Node, or the
+browser, in addition to its [command-line interface](../user_guide/command-line.md).
+This page covers programmatic use. The auto-generated API reference,
+which is the source of truth for type signatures, is hosted on
+[JSR](https://jsr.io/@bids/validator/doc).
+
+## Installing
+
+The validator is published to [JSR](https://jsr.io/@bids/validator) as
+`@bids/validator`. From a Deno project:
+
+```console
+$ deno add jsr:@bids/validator
+```
+
+For Node and bundler-based projects, install via the JSR-to-npm bridge:
+
+```console
+$ npx jsr add @bids/validator
+```
+
+## A minimal example
+
+The smallest useful program loads a dataset from disk into a `FileTree`
+and runs `validate` against it:
+
+```ts
+import { readFileTree } from '@bids/validator/files'
+import { validate } from '@bids/validator/main'
+
+const datasetPath = '/path/to/dataset'
+const tree = await readFileTree(datasetPath)
+const result = await validate(tree, {
+  datasetPath,
+  debug: 'ERROR',
+  datasetTypes: [],
+  blacklistModalities: [],
+})
+
+console.log(`${result.issues.size} issues found`)
+console.log(`Validated against schema ${result.summary.schemaVersion}`)
+```
+
+`readFileTree` requires read access to the dataset directory; run the
+program with `deno run -R=/path/to/dataset script.ts` (or `-ERWN` for
+the same set of permissions used by the published CLI).
+
+## Working with the result
+
+`validate` returns a `ValidationResult`:
+
+```ts
+interface ValidationResult {
+  issues: DatasetIssues
+  summary: SummaryOutput
+  derivativesSummary?: Record<string, ValidationResult>
+}
+```
+
+- `issues` — a [`DatasetIssues`](https://jsr.io/@bids/validator/doc/issues/~/DatasetIssues)
+  collection. Iterate over `result.issues.issues` to get the flat list,
+  or call `result.issues.groupBy('code')` to group by issue type. See
+  [Understanding issues](../user_guide/issues.md) for the issue model.
+- `summary` — counts and metadata about the validated dataset
+  (subjects, sessions, modalities, schema version).
+- `derivativesSummary` — present only when `options.recursive` is set;
+  maps each BIDS derivative dataset name to its own `ValidationResult`.
+
+To enumerate every issue with its severity and location:
+
+```ts
+for (const issue of result.issues.issues) {
+  console.log(`${issue.severity ?? 'error'}: ${issue.code} (${issue.location ?? 'no location'})`)
+}
+```
+
+To filter by severity or code:
+
+```ts
+const errors = result.issues.filter({ severity: 'error' })
+const missingFiles = result.issues.filter({ code: 'MISSING_DATASET_DESCRIPTION' })
+```
+
+## Browser and in-memory usage
+
+In a browser, you typically have a `File[]` from a file input or
+drag-and-drop event rather than a path on disk. Use `fileListToTree`
+to construct a `FileTree` directly from the file list:
+
+```ts
+import { fileListToTree, validate } from '@bids/validator/main'
+
+async function validateUserSelection(files: File[]) {
+  const tree = await fileListToTree(files)
+  return validate(tree, {
+    datasetPath: '<browser-supplied dataset>',
+    debug: 'ERROR',
+    datasetTypes: [],
+    blacklistModalities: [],
+  })
+}
+```
+
+`fileListToTree` lives in `src/files/browser.ts` and is re-exported from
+`@bids/validator/main` for convenience.
+
+## Entry points
+
+The package exposes the following entry points (defined in `deno.json`):
+
+| Import path                | Source                          | Purpose                                              |
+| -------------------------- | ------------------------------- | ---------------------------------------------------- |
+| `@bids/validator`          | `src/bids-validator.ts`         | CLI entry point — not intended for library use.      |
+| `@bids/validator/main`     | `src/main.ts`                   | Library API: `validate`, `fileListToTree`, `getVersion`, `ValidationResult` type. |
+| `@bids/validator/files`    | `src/files/deno.ts`             | Deno-side file-tree construction (`readFileTree`, `BIDSFileDeno`). |
+| `@bids/validator/options`  | `src/setup/options.ts`          | `ValidatorOptions` and `Config` types; CLI option parser. |
+| `@bids/validator/issues`   | `src/issues/datasetIssues.ts`   | `DatasetIssues` container and types.                 |
+| `@bids/validator/output`   | `src/utils/output.ts`           | Result formatting (`consoleFormat`, `resultToJSONStr`). |
+
+For full type signatures of every export, see the
+[API reference on JSR](https://jsr.io/@bids/validator/doc).

--- a/src/issues/datasetIssues.ts
+++ b/src/issues/datasetIssues.ts
@@ -9,6 +9,15 @@ const _CODE_DEPRECATED = Number.MIN_SAFE_INTEGER
 
 type Group = Map<Issue[keyof Issue], DatasetIssues | Group | undefined>
 
+/**
+ * Container for {@link Issue}s accumulated during validation.
+ *
+ * Holds a flat list of issues plus a `codeMessages` map that records the
+ * human-readable description for each distinct issue code seen so far.
+ * Most validators interact with a `DatasetIssues` via the `issues`
+ * property of a `BIDSContext` or `BIDSContextDataset` rather than
+ * constructing one directly.
+ */
 export class DatasetIssues {
   issues: Issue[]
   codeMessages: Map<string, string>
@@ -20,6 +29,23 @@ export class DatasetIssues {
     this.codeMessages = codeMessages ?? new Map()
   }
 
+  /**
+   * Append an issue to the collection.
+   *
+   * If `codeMessage` is not provided, `add` looks up `issue.code` in the
+   * built-in non-schema issue catalogue and uses its description and
+   * default severity. The catalogue is defined in
+   * `src/issues/list.ts`.
+   *
+   * @param issue - The issue to record. Only the fields recognised by
+   *   `filterIssue` are kept; extras are dropped to protect against
+   *   payloads from external validators.
+   * @param codeMessage - Optional human-readable description for
+   *   `issue.code`. Required when `issue.code` is not in the non-schema
+   *   issue catalogue.
+   * @throws {Error} If `codeMessage` is not provided and `issue.code`
+   *   is not a key in the non-schema issue catalogue.
+   */
   add(issue: Issue, codeMessage?: string) {
     // Ensure only relevant fields are kept, for protection when working with
     // external validators

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -39,7 +39,48 @@ const perDSChecks: DSCheckFunction[] = [
 ]
 
 /**
- * Full BIDS schema validation entrypoint
+ * Validate a BIDS dataset against the BIDS schema.
+ *
+ * Loads the BIDS schema, walks the file tree, and applies file-level and
+ * dataset-level checks, accumulating any issues into the returned
+ * {@link ValidationResult}. Derivative datasets nested under
+ * `derivatives/` are detected via their own `dataset_description.json`;
+ * when `options.recursive` is set, BIDS-conformant derivatives are
+ * validated and their results attached to `derivativesSummary` on the
+ * returned object. Non-BIDS derivatives and the `sourcedata`/`code`
+ * directories are ignored.
+ *
+ * `validate` does not throw on validation failures — it records them as
+ * issues on the result. The returned `issues` collection can be filtered
+ * or grouped via `DatasetIssues` methods. Set `options.ignoreWarnings`
+ * to drop non-error issues from the output.
+ *
+ * @param fileTree - Root of the dataset to validate, typically produced
+ *   by `readFileTree` (Deno) or `fileListToTree` (browser).
+ * @param options - Per-run options. See {@link ValidatorOptions}.
+ *   Notable fields include `recursive`, `ignoreWarnings`, and
+ *   `blacklistModalities`.
+ * @param config - Optional severity-override map. Each top-level key
+ *   (`ignore`, `warning`, `error`) lists partial issue patterns;
+ *   matching issues are reassigned to that severity after the run.
+ * @returns A {@link ValidationResult} containing the accumulated
+ *   issues, the run summary, and (when `options.recursive` is set)
+ *   the per-derivative validation results.
+ *
+ * @example
+ * ```ts
+ * import { readFileTree } from '@bids/validator/files'
+ * import { validate } from '@bids/validator/main'
+ *
+ * const tree = await readFileTree('/path/to/dataset')
+ * const result = await validate(tree, {
+ *   datasetPath: '/path/to/dataset',
+ *   debug: 'ERROR',
+ *   datasetTypes: [],
+ *   blacklistModalities: [],
+ * })
+ * console.log(`${result.issues.size} issues found`)
+ * ```
  */
 export async function validate(
   fileTree: FileTree,


### PR DESCRIPTION
* Updates the https://bids-validator.readthedocs.io/en/latest/dev/using-the-api.html stub
* Improves docstrings for `validate` entrypoint and `DatasetIssues`