### PR TITLE
feat: Report broken symlinks

### DIFF
--- a/changelog.d/20260410_165627_markiewicz_symlink_handling.md
+++ b/changelog.d/20260410_165627_markiewicz_symlink_handling.md
@@ -1,0 +1,9 @@
+### Added
+
+- Report broken symbolic links as issues instead of crashing or silently ignoring.
+  `.bidsignore`d links are not reported. If resolution is not implemented, warnings
+  are issued instead of errors.
+
+### Fixed
+
+- Treat symbolic links to directories as directories instead of files.

--- a/docs/dev/discussion/2026-04-symlink_handling.md
+++ b/docs/dev/discussion/2026-04-symlink_handling.md
@@ -4,6 +4,21 @@
 
 Discussion document. Not yet a specification.
 
+## Implementation status
+
+Bugs 1, 2, and 3 from the "Summary of Current Bugs" section are fixed on
+branch `fix/symlink-handling`:
+
+- Work-tree directory symlinks now fall through to directory recursion.
+- Work-tree dangling non-annex symlinks are recorded as broken link
+  entries on `FileTree.links` instead of crashing `parseAnnexedFile`.
+- Git-tree unresolvable symlinks (broken, cyclic, out-of-tree, submodule,
+  directory target) are recorded on `FileTree.links` and surfaced as
+  `SYMLINK_*` issues during validation, gated by `.bidsignore`.
+
+Directory-symlink grafting in the git tree remains deferred (see Design
+Question 5 and the "directory-unsupported" reason on `UnresolvedLink`).
+
 ## Problem
 
 The validator has two tree-building backends: work tree (`deno.ts`, reads the

--- a/docs/dev/discussion/2026-04-symlink_handling.md
+++ b/docs/dev/discussion/2026-04-symlink_handling.md
@@ -6,8 +6,8 @@ Discussion document. Not yet a specification.
 
 ## Implementation status
 
-Bugs 1, 2, and 3 from the "Summary of Current Bugs" section are fixed on
-branch `fix/symlink-handling`:
+Bugs 1, 2, and 3 from the "Summary of Current Bugs" section are fixed in
+PR [#380](https://github.com/bids-standard/bids-validator/pull/380):
 
 - Work-tree directory symlinks now fall through to directory recursion.
 - Work-tree dangling non-annex symlinks are recorded as broken link

--- a/src/files/deno.test.ts
+++ b/src/files/deno.test.ts
@@ -91,3 +91,151 @@ Deno.test('Deno implementation of FileTree', async (t) => {
     assert(!prunedTree.get(derivFile))
   })
 })
+
+const isWindows = Deno.build.os === 'windows'
+
+async function withTempDataset(
+  setup: (root: string) => Promise<void>,
+  body: (root: string) => Promise<void>,
+): Promise<void> {
+  const root = await Deno.makeTempDir()
+  try {
+    await setup(root)
+    await body(root)
+  } finally {
+    await new Deno.Command('chmod', { args: ['-R', '+w', root] }).output()
+    await Deno.remove(root, { recursive: true })
+  }
+}
+
+Deno.test({
+  name: 'readFileTree: symlink to in-tree file resolves',
+  ignore: isWindows,
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  await withTempDataset(
+    async (root) => {
+      await Deno.writeTextFile(join(root, 'real.txt'), 'hello')
+      await Deno.symlink('real.txt', join(root, 'link.txt'))
+    },
+    async (root) => {
+      const tree = await readFileTree(root)
+      const link = tree.get('link.txt')
+      assert(link !== undefined, 'link.txt should be in tree.files')
+      assertEquals(tree.links.length, 0, 'no unresolved links expected')
+    },
+  )
+})
+
+Deno.test({
+  name: 'readFileTree: symlink to in-tree directory recurses (bug 1 regression)',
+  ignore: isWindows,
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  await withTempDataset(
+    async (root) => {
+      await Deno.mkdir(join(root, 'real-dir'))
+      await Deno.writeTextFile(join(root, 'real-dir', 'inner.txt'), 'content')
+      await Deno.symlink('real-dir', join(root, 'linked-dir'))
+    },
+    async (root) => {
+      const tree = await readFileTree(root)
+      const inner = tree.get('linked-dir/inner.txt')
+      assert(inner !== undefined, 'linked-dir/inner.txt should appear via directory symlink')
+      assertEquals(tree.links.length, 0)
+    },
+  )
+})
+
+Deno.test({
+  name: 'readFileTree: dangling symlink produces a broken link entry (bug 2 regression)',
+  ignore: isWindows,
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  await withTempDataset(
+    async (root) => {
+      await Deno.symlink('nowhere.txt', join(root, 'broken.txt'))
+    },
+    async (root) => {
+      const tree = await readFileTree(root)
+      assertEquals(tree.get('broken.txt'), undefined, 'broken link should not be in tree.files')
+      assertEquals(tree.links.length, 1)
+      assertEquals(tree.links[0].path, '/broken.txt')
+      assertEquals(tree.links[0].target, 'nowhere.txt')
+      assertEquals(tree.links[0].reason, 'broken')
+    },
+  )
+})
+
+Deno.test({
+  name: 'readFileTree: cyclic symlinks produce a cycle link entry',
+  ignore: isWindows,
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  await withTempDataset(
+    async (root) => {
+      await Deno.symlink('cycle-b', join(root, 'cycle-a'))
+      await Deno.symlink('cycle-a', join(root, 'cycle-b'))
+    },
+    async (root) => {
+      const tree = await readFileTree(root)
+      const cycleLinks = tree.links.filter((l) => l.reason === 'cycle')
+      assertEquals(cycleLinks.length, 2, 'both cycle-a and cycle-b should report cycle')
+    },
+  )
+})
+
+Deno.test({
+  name: 'readFileTree: annex pointer symlink is classified as a file',
+  ignore: isWindows,
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  const annexTarget =
+    '../../.git/annex/objects/xx/yy/MD5E-s1234--d41d8cd98f00b204e9800998ecf8427e.nii.gz/MD5E-s1234--d41d8cd98f00b204e9800998ecf8427e.nii.gz'
+  await withTempDataset(
+    async (root) => {
+      await Deno.mkdir(join(root, '.git', 'annex', 'objects'), { recursive: true })
+      await Deno.mkdir(join(root, 'sub-01', 'func'), { recursive: true })
+      await Deno.symlink(
+        annexTarget,
+        join(root, 'sub-01', 'func', 'sub-01_task-rest_bold.nii.gz'),
+      )
+    },
+    async (root) => {
+      const tree = await readFileTree(root)
+      const file = tree.get('sub-01/func/sub-01_task-rest_bold.nii.gz')
+      assert(file !== undefined, 'annex pointer should appear in tree.files')
+      assertEquals(tree.links.length, 0, 'annex pointer should not be in tree.links')
+    },
+  )
+})
+
+Deno.test({
+  name: 'readFileTree: out-of-tree file symlink is transparently followed',
+  ignore: isWindows,
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  const externalDir = await Deno.makeTempDir()
+  await Deno.writeTextFile(join(externalDir, 'external.txt'), 'outside')
+  try {
+    await withTempDataset(
+      async (root) => {
+        await Deno.symlink(join(externalDir, 'external.txt'), join(root, 'external.txt'))
+      },
+      async (root) => {
+        const tree = await readFileTree(root)
+        const ext = tree.get('external.txt')
+        assert(ext !== undefined, 'out-of-tree file symlink should appear via OS resolution')
+        assertEquals(tree.links.length, 0)
+      },
+    )
+  } finally {
+    await Deno.remove(externalDir, { recursive: true })
+  }
+})

--- a/src/files/deno.test.ts
+++ b/src/files/deno.test.ts
@@ -7,6 +7,8 @@ import { BIDSFileDeno, readFileTree } from './deno.ts'
 import { UnicodeDecodeError } from './streams.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
 import { FileIgnoreRules } from './ignore.ts'
+import { BIDSContextDataset } from '../schema/context.ts'
+import { walkFileTree } from '../schema/walk.ts'
 
 await requestReadPermission()
 
@@ -238,4 +240,35 @@ Deno.test({
   } finally {
     await Deno.remove(externalDir, { recursive: true })
   }
+})
+
+Deno.test({
+  name: 'readFileTree + walkFileTree: reports broken and cycle links end-to-end',
+  ignore: isWindows,
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
+  await withTempDataset(
+    async (root) => {
+      // One valid file so the tree is non-empty.
+      await Deno.writeTextFile(join(root, 'dataset_description.json'), '{}')
+      // Broken link.
+      await Deno.symlink('nowhere.txt', join(root, 'broken.txt'))
+      // Cycle.
+      await Deno.symlink('cycle-b', join(root, 'cycle-a'))
+      await Deno.symlink('cycle-a', join(root, 'cycle-b'))
+    },
+    async (root) => {
+      const tree = await readFileTree(root)
+      const ds = new BIDSContextDataset({ tree })
+      for await (const _ of walkFileTree(ds)) { /* consume */ }
+
+      const brokenIssues = ds.issues.get({ code: 'SYMLINK_BROKEN' })
+      assertEquals(brokenIssues.length, 1)
+      assertEquals(brokenIssues[0].location, '/broken.txt')
+
+      const cycleIssues = ds.issues.get({ code: 'SYMLINK_CYCLE' })
+      assertEquals(cycleIssues.length, 2)
+    },
+  )
 })

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -8,7 +8,7 @@ import { requestReadPermission } from '../setup/requestPermissions.ts'
 import { FileIgnoreRules } from './ignore.ts'
 import { loadBidsIgnore } from './filetree.ts'
 import { FsFileOpener } from './openers.ts'
-import { parseAnnexedFile, parseAnnexKey } from './repo.ts'
+import { gitdirFromLink, parseAnnexKey } from './repo.ts'
 import { AnnexedGitFileOpener } from './git.ts'
 import fs from 'node:fs'
 
@@ -60,7 +60,7 @@ async function _readFileTree({
       // Annex pointers are identified from the raw target string; no stat needed.
       const annexParsed = parseAnnexKey(target)
       if (annexParsed !== null) {
-        const { gitdir } = await parseAnnexedFile(fullPath)
+        const gitdir = gitdirFromLink(fullPath, target)
         const opener = new AnnexedGitFileOpener(
           annexParsed.key,
           annexParsed.size,

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -64,7 +64,6 @@ async function _readFileTree({
         const opener = new AnnexedGitFileOpener(
           annexParsed.key,
           annexParsed.size,
-          gitdir,
           { cache, fs, gitdir },
           preferredRemote,
         )

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -3,12 +3,12 @@
  */
 import { basename, join } from '@std/path'
 import * as posix from '@std/path/posix'
-import { BIDSFile, type FileOpener, FileTree } from '../types/filetree.ts'
+import { BIDSFile, FileTree, type SymlinkReason } from '../types/filetree.ts'
 import { requestReadPermission } from '../setup/requestPermissions.ts'
 import { FileIgnoreRules } from './ignore.ts'
 import { loadBidsIgnore } from './filetree.ts'
 import { FsFileOpener } from './openers.ts'
-import { parseAnnexedFile } from './repo.ts'
+import { parseAnnexedFile, parseAnnexKey } from './repo.ts'
 import { AnnexedGitFileOpener } from './git.ts'
 import fs from 'node:fs'
 
@@ -47,25 +47,47 @@ async function _readFileTree({
     if (prune.test(thisPath)) {
       continue
     }
-    if (dirEntry.isFile || dirEntry.isSymlink) {
-      let opener: FileOpener
+
+    // Symlinks are classified here and then fall through to the file or
+    // directory branches below via the effective flags computed from stat().
+    let { isFile, isDirectory } = dirEntry
+    let fileInfo: Deno.FileInfo | undefined
+
+    if (dirEntry.isSymlink) {
       const fullPath = join(rootPath, thisPath)
-      try {
-        const fileInfo = await Deno.stat(fullPath)
-        opener = new FsFileOpener(rootPath, thisPath, fileInfo)
-      } catch (_) {
-        const { key, size, gitdir } = await parseAnnexedFile(fullPath)
-        opener = new AnnexedGitFileOpener(
-          key,
-          size,
+      const target = await Deno.readLink(fullPath)
+
+      // Annex pointers are identified from the raw target string; no stat needed.
+      const annexParsed = parseAnnexKey(target)
+      if (annexParsed !== null) {
+        const { gitdir } = await parseAnnexedFile(fullPath)
+        const opener = new AnnexedGitFileOpener(
+          annexParsed.key,
+          annexParsed.size,
           gitdir,
           { cache, fs, gitdir },
           preferredRemote,
         )
+        tree.files.push(new BIDSFile(thisPath, opener, ignore, tree))
+        continue
       }
-      tree.files.push(new BIDSFile(thisPath, opener, ignore, tree))
+
+      try {
+        fileInfo = await Deno.stat(fullPath)
+      } catch (err) {
+        const code = (err as { code?: string }).code
+        const reason: SymlinkReason = code === 'ELOOP' ? 'cycle' : 'broken'
+        tree.links.push({ path: '/' + thisPath.replace(/^\/+/, ''), target, reason })
+        continue
+      }
+
+      ;({ isFile, isDirectory } = fileInfo)
     }
-    if (dirEntry.isDirectory) {
+
+    if (isFile) {
+      const opener = new FsFileOpener(rootPath, thisPath, fileInfo)
+      tree.files.push(new BIDSFile(thisPath, opener, ignore, tree))
+    } else if (isDirectory) {
       const dirTree = await _readFileTree({
         rootPath,
         relativePath: thisPath,

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -75,7 +75,14 @@ async function _readFileTree({
         fileInfo = await Deno.stat(fullPath)
       } catch (err) {
         const code = (err as { code?: string }).code
-        const reason: SymlinkReason = code === 'ELOOP' ? 'cycle' : 'broken'
+        let reason: SymlinkReason
+        if (code === 'ELOOP') {
+          reason = 'cycle'
+        } else if (code === 'ENOENT') {
+          reason = 'broken'
+        } else {
+          throw err
+        }
         tree.links.push({ path: '/' + thisPath.replace(/^\/+/, ''), target, reason })
         continue
       }

--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -142,3 +142,10 @@ Deno.test('FileTree.links accepts UnresolvedLink records', () => {
   assertEquals(tree.links.length, 1)
   assertEquals(tree.links[0].reason, 'broken')
 })
+
+Deno.test('FileTree.isPathIgnored delegates to its FileIgnoreRules', () => {
+  const rules = new FileIgnoreRules(['/ignored/**'])
+  const tree = new FileTree('/', '/', undefined, rules)
+  assertEquals(tree.isPathIgnored('/ignored/foo.txt'), true)
+  assertEquals(tree.isPathIgnored('/kept/bar.txt'), false)
+})

--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -106,6 +106,38 @@ Deno.test('extract subtrees', async (t) => {
     )
   })
 
+  await t.step('Subtree preserves unresolved links with rebased paths', async () => {
+    const tree = pathsToTree([
+      '/dataset_description.json',
+      '/derivatives/pipeline/dataset_description.json',
+    ])
+    const pipeline = tree.get('derivatives/pipeline') as FileTree
+    pipeline.links.push({
+      path: '/derivatives/pipeline/broken.txt',
+      target: '../does-not-exist',
+      reason: 'broken',
+    })
+    const anat = new FileTree(
+      '/derivatives/pipeline/sub-01',
+      'sub-01',
+      pipeline,
+    )
+    anat.links.push({
+      path: '/derivatives/pipeline/sub-01/dangling.nii.gz',
+      target: 'nowhere.nii.gz',
+      reason: 'broken',
+    })
+    pipeline.directories.push(anat)
+
+    const derivTree = await subtree(pipeline)
+    assertEquals(derivTree.links.length, 1)
+    assertEquals(derivTree.links[0].path, '/broken.txt')
+    assertEquals(derivTree.links[0].reason, 'broken')
+    const subdir = derivTree.get('sub-01') as FileTree
+    assertEquals(subdir.links.length, 1)
+    assertEquals(subdir.links[0].path, '/sub-01/dangling.nii.gz')
+  })
+
   await t.step('Subtree uses new bidsignore', async () => {
     const tree = pathsToTree([
       '/dataset_description.json',

--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -1,6 +1,6 @@
 import { assert, assertEquals } from '@std/assert'
 import { FileIgnoreRules } from './ignore.ts'
-import { BIDSFile, type FileTree } from '../types/filetree.ts'
+import { BIDSFile, FileTree } from '../types/filetree.ts'
 import { filesToTree, subtree } from './filetree.ts'
 import { StringOpener } from './openers.test.ts'
 
@@ -125,4 +125,20 @@ Deno.test('extract subtrees', async (t) => {
     assertEquals(pipeline.get('also_ignored_file')!.ignored, true)
     assertEquals(pipeline.get('ignored_file')!.ignored, false)
   })
+})
+
+Deno.test('FileTree initialises an empty links array', () => {
+  const tree = new FileTree('/some/path', 'path')
+  assertEquals(tree.links, [])
+})
+
+Deno.test('FileTree.links accepts UnresolvedLink records', () => {
+  const tree = new FileTree('/some/path', 'path')
+  tree.links.push({
+    path: '/some/path/broken',
+    target: '../does-not-exist',
+    reason: 'broken',
+  })
+  assertEquals(tree.links.length, 1)
+  assertEquals(tree.links[0].reason, 'broken')
 })

--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -2,6 +2,7 @@ import { assert, assertEquals } from '@std/assert'
 import { FileIgnoreRules } from './ignore.ts'
 import { BIDSFile, FileTree } from '../types/filetree.ts'
 import { filesToTree, subtree } from './filetree.ts'
+import { NullFileOpener } from './openers.ts'
 import { StringOpener } from './openers.test.ts'
 
 export function pathToFile(path: string, ignored: boolean = false): BIDSFile {
@@ -148,4 +149,33 @@ Deno.test('FileTree.isPathIgnored delegates to its FileIgnoreRules', () => {
   const tree = new FileTree('/', '/', undefined, rules)
   assertEquals(tree.isPathIgnored('/ignored/foo.txt'), true)
   assertEquals(tree.isPathIgnored('/kept/bar.txt'), false)
+})
+
+Deno.test('filesToTree attaches unresolved links to their parent directory', () => {
+  const file = new BIDSFile('/sub-01/anat/sub-01_T1w.json', new NullFileOpener(0))
+  const tree = filesToTree([file], undefined, [
+    {
+      path: '/sub-01/anat/broken.nii.gz',
+      target: '../nope.nii.gz',
+      reason: 'broken',
+    },
+  ])
+
+  const anat = tree.get('sub-01/anat')
+  assert(anat !== undefined, 'sub-01/anat should exist in tree')
+  assertEquals((anat as FileTree).links.length, 1)
+  assertEquals((anat as FileTree).links[0].path, '/sub-01/anat/broken.nii.gz')
+})
+
+Deno.test('filesToTree creates intermediate directories for a link-only path', () => {
+  const tree = filesToTree([], undefined, [
+    {
+      path: '/a/b/c/dangling.txt',
+      target: 'nowhere',
+      reason: 'broken',
+    },
+  ])
+  const c = tree.get('a/b/c')
+  assert(c !== undefined, '/a/b/c should be created for the link')
+  assertEquals((c as FileTree).links.length, 1)
 })

--- a/src/files/filetree.ts
+++ b/src/files/filetree.ts
@@ -5,8 +5,9 @@ import { FileIgnoreRules, readBidsIgnore } from './ignore.ts'
 
 /**
  * Walk a posix path and return the FileTree corresponding to its directory,
- * creating intermediate directory nodes as needed. Does not attach the final
- * segment; that's the caller's job.
+ * creating intermediate directory nodes as needed.
+ * Pass the parent directory of the object to insert.
+ * Inserting the file or link is the caller's responsibility.
  */
 function descendTo(root: FileTree, dir: string, ignore: FileIgnoreRules): FileTree {
   if (dir === '/') return root

--- a/src/files/filetree.ts
+++ b/src/files/filetree.ts
@@ -1,31 +1,46 @@
 import { parse, SEPARATOR_PATTERN } from '@std/path'
 import * as posix from '@std/path/posix'
-import { BIDSFile, FileTree } from '../types/filetree.ts'
+import { BIDSFile, FileTree, type UnresolvedLink } from '../types/filetree.ts'
 import { FileIgnoreRules, readBidsIgnore } from './ignore.ts'
 
-export function filesToTree(fileList: BIDSFile[], ignore?: FileIgnoreRules): FileTree {
+/**
+ * Walk a posix path and return the FileTree corresponding to its directory,
+ * creating intermediate directory nodes as needed. Does not attach the final
+ * segment; that's the caller's job.
+ */
+function descendTo(root: FileTree, dir: string, ignore: FileIgnoreRules): FileTree {
+  if (dir === '/') return root
+  let current = root
+  for (const level of dir.split(SEPARATOR_PATTERN).slice(1)) {
+    const exists = current.get(level) as FileTree
+    if (exists) {
+      current = exists
+      continue
+    }
+    const newTree = new FileTree(posix.join(current.path, level), level, current, ignore)
+    current.directories.push(newTree)
+    current = newTree
+  }
+  return current
+}
+
+export function filesToTree(
+  fileList: BIDSFile[],
+  ignore?: FileIgnoreRules,
+  unresolvedLinks: UnresolvedLink[] = [],
+): FileTree {
   ignore = ignore ?? new FileIgnoreRules([])
   const tree: FileTree = new FileTree('/', '/')
   for (const file of fileList) {
     const parts = parse(file.path)
-    if (parts.dir === '/') {
-      tree.files.push(file)
-      file.parent = tree
-      continue
-    }
-    let current = tree
-    for (const level of parts.dir.split(SEPARATOR_PATTERN).slice(1)) {
-      const exists = current.get(level) as FileTree
-      if (exists) {
-        current = exists
-        continue
-      }
-      const newTree = new FileTree(posix.join(current.path, level), level, current, ignore)
-      current.directories.push(newTree)
-      current = newTree
-    }
-    current.files.push(file)
-    file.parent = current
+    const parent = descendTo(tree, parts.dir, ignore)
+    parent.files.push(file)
+    file.parent = parent
+  }
+  for (const link of unresolvedLinks) {
+    const parts = parse(link.path)
+    const parent = descendTo(tree, parts.dir, ignore)
+    parent.links.push(link)
   }
   return tree
 }

--- a/src/files/filetree.ts
+++ b/src/files/filetree.ts
@@ -70,6 +70,10 @@ function rerootTree({
   tree.directories = oldTree.directories.map((dir) =>
     rerootTree({ oldTree: dir, newRoot, ignore, parent: tree })
   )
+  tree.links = oldTree.links.map((link) => ({
+    ...link,
+    path: link.path.substr(newRoot.length),
+  }))
   return tree
 }
 

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -276,7 +276,7 @@ Deno.test(
 
 Deno.test(
   {
-    name: 'readGitTree: symlink cycle is silently dropped',
+    name: 'readGitTree: symlink cycle is recorded as a cycle link entry',
     ignore: !hasGit || isWindows,
     sanitizeResources: false,
     sanitizeOps: false,
@@ -292,34 +292,10 @@ Deno.test(
         const tree = await readGitTree(repo)
         const safe = tree.get('safe.txt')
         assertExists(safe, 'safe.txt should be in tree')
-        const cycleA = tree.get('cycle_a')
-        const cycleB = tree.get('cycle_b')
-        assertEquals(cycleA, undefined, 'cycle_a should be dropped')
-        assertEquals(cycleB, undefined, 'cycle_b should be dropped')
-      },
-    )
-  },
-)
-
-Deno.test(
-  {
-    name: 'readGitTree: broken symlink is silently dropped',
-    ignore: !hasGit || isWindows,
-    sanitizeResources: false,
-    sanitizeOps: false,
-  },
-  async () => {
-    await withRepo(
-      async (repo) => {
-        await Deno.writeTextFile(join(repo, 'exists.txt'), 'here')
-        await run(['ln', '-s', 'nonexistent.txt', join(repo, 'broken.txt')])
-      },
-      async (repo) => {
-        const tree = await readGitTree(repo)
-        const exists = tree.get('exists.txt')
-        assertExists(exists, 'exists.txt should be in tree')
-        const broken = tree.get('broken.txt')
-        assertEquals(broken, undefined, 'broken.txt should be dropped')
+        assertEquals(tree.get('cycle_a'), undefined, 'cycle_a should not be in files')
+        assertEquals(tree.get('cycle_b'), undefined, 'cycle_b should not be in files')
+        const cycleLinks = tree.links.filter((l) => l.reason === 'cycle')
+        assertEquals(cycleLinks.length, 2, 'both cycle_a and cycle_b should be reported')
       },
     )
   },
@@ -485,5 +461,105 @@ Deno.test(
       await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()
       await Deno.remove(tmpDir, { recursive: true })
     }
+  },
+)
+
+// ---------------------------------------------------------------------------
+// SymlinkReason surface tests
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  {
+    name: 'readGitTree: absolute-target symlink is out-of-tree',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await run(['ln', '-s', '/etc/passwd', join(repo, 'abs.txt')])
+      },
+      async (repo) => {
+        const tree = await readGitTree(repo)
+        assertEquals(tree.get('abs.txt'), undefined, 'abs.txt must not be in files')
+        assertEquals(tree.links.length, 1)
+        assertEquals(tree.links[0].reason, 'out-of-tree')
+        assertEquals(tree.links[0].path, '/abs.txt')
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'readGitTree: relative symlink escaping repo root is out-of-tree',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'sub'))
+        await run(['ln', '-s', '../../outside', join(repo, 'sub', 'escape.txt')])
+      },
+      async (repo) => {
+        const tree = await readGitTree(repo)
+        const escapeLinks = tree.links.filter((l) => l.reason === 'out-of-tree')
+        assertEquals(escapeLinks.length, 1)
+        assertEquals(escapeLinks[0].path, '/sub/escape.txt')
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'readGitTree: symlink to a committed directory is directory-unsupported',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'real-dir'))
+        await Deno.writeTextFile(join(repo, 'real-dir', 'inside.txt'), 'content')
+        await run(['ln', '-s', 'real-dir', join(repo, 'linked-dir')])
+      },
+      async (repo) => {
+        const tree = await readGitTree(repo)
+        assertEquals(tree.get('linked-dir'), undefined, 'linked-dir must not be in files')
+        const dirLinks = tree.links.filter((l) => l.reason === 'directory-unsupported')
+        assertEquals(dirLinks.length, 1)
+        assertEquals(dirLinks[0].path, '/linked-dir')
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'readGitTree: broken symlink is recorded as a broken link entry',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.writeTextFile(join(repo, 'exists.txt'), 'here')
+        await run(['ln', '-s', 'nonexistent.txt', join(repo, 'broken.txt')])
+      },
+      async (repo) => {
+        const tree = await readGitTree(repo)
+        assertEquals(tree.get('broken.txt'), undefined, 'broken.txt must not be in files')
+        const brokenLinks = tree.links.filter((l) => l.reason === 'broken')
+        assertEquals(brokenLinks.length, 1)
+        assertEquals(brokenLinks[0].path, '/broken.txt')
+        assertEquals(brokenLinks[0].target, 'nonexistent.txt')
+      },
+    )
   },
 )

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -506,7 +506,10 @@ Deno.test(
       },
       async (repo) => {
         const tree = await readGitTree(repo)
-        const escapeLinks = tree.links.filter((l) => l.reason === 'out-of-tree')
+        // The link lives under /sub, so look in the sub directory node
+        const subTree = tree.get('sub')
+        assertExists(subTree, 'sub directory should exist')
+        const escapeLinks = (subTree as FileTree).links.filter((l) => l.reason === 'out-of-tree')
         assertEquals(escapeLinks.length, 1)
         assertEquals(escapeLinks[0].path, '/sub/escape.txt')
       },

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -197,7 +197,7 @@ async function ancestorIsSubmodule(
         ...gitOptions,
       })
       if (parentObj.type !== 'tree') return false
-      // The tree type exposes `entries` as an array of { mode, path, oid, type }.
+      // isomorphic-git `ParsedTreeObject` exposes `object` as `TreeEntry[]`, with TreeEntry being an object with fields { mode, path, oid, type }.
       // deno-lint-ignore no-explicit-any
       const entries = (parentObj as unknown as { object: { entries: any[] } }).object.entries
       const match = entries.find((e: { path: string }) => e.path === segment)

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -205,8 +205,9 @@ async function ancestorIsSubmodule(
       if (match.type === 'commit') return true
       if (match.type !== 'tree') return false
       prefix = prefix === '' ? segment : `${prefix}/${segment}`
-    } catch {
-      return false
+    } catch (err: unknown) {
+      if (err && typeof err == 'object' && 'isIsomorphicGitError' in err) return false
+      throw err
     }
   }
   return false

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -80,7 +80,6 @@ export class GitFileOpener implements FileOpener {
 export class AnnexedGitFileOpener implements FileOpener {
   size: number
   #key: string
-  #gitdir: string
   #gitOptions: GitOptions
   #preferredRemote: string | undefined
   #delegate: FileOpener | undefined
@@ -88,13 +87,11 @@ export class AnnexedGitFileOpener implements FileOpener {
   constructor(
     key: string,
     size: number,
-    gitdir: string,
     gitOptions: GitOptions,
     preferredRemote?: string,
   ) {
     this.#key = key
     this.size = size
-    this.#gitdir = gitdir
     this.#gitOptions = gitOptions
     this.#preferredRemote = preferredRemote
   }
@@ -106,7 +103,15 @@ export class AnnexedGitFileOpener implements FileOpener {
 
     // 1. Try local annex object store
     const [h0, h1] = await hashDirLower(this.#key)
-    const localPath = join(this.#gitdir, 'annex', 'objects', h0, h1, this.#key, this.#key)
+    const localPath = join(
+      this.#gitOptions.gitdir,
+      'annex',
+      'objects',
+      h0,
+      h1,
+      this.#key,
+      this.#key,
+    )
     try {
       await Deno.stat(localPath)
       this.#delegate = new FsFileOpener('', localPath)
@@ -219,7 +224,6 @@ async function resolveSymlinkInTree(
   filepath: string,
   target: string,
   commitOid: string,
-  gitdir: string,
   gitOptions: GitOptions,
   symlinkMap: Map<string, string>,
   preferredRemote?: string,
@@ -242,7 +246,6 @@ async function resolveSymlinkInTree(
           opener: new AnnexedGitFileOpener(
             annexParsed.key,
             annexParsed.size,
-            gitdir,
             gitOptions,
             preferredRemote,
           ),
@@ -389,7 +392,6 @@ export async function readGitTree(
             opener = new AnnexedGitFileOpener(
               annexParsed.key,
               annexParsed.size,
-              gitdir,
               gitOptions,
               preferredRemote,
             )
@@ -421,7 +423,6 @@ export async function readGitTree(
       filepath,
       target,
       resolvedOid,
-      gitdir,
       gitOptions,
       symlinkMap,
       preferredRemote,

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -10,7 +10,13 @@ import type { WalkerEntry } from 'isomorphic-git'
 import fs from 'node:fs'
 import * as posix from '@std/path/posix'
 import { join } from '@std/path'
-import { BIDSFile, type FileOpener, type FileTree } from '../types/filetree.ts'
+import {
+  BIDSFile,
+  type FileOpener,
+  type FileTree,
+  type SymlinkReason,
+  type UnresolvedLink,
+} from '../types/filetree.ts'
 import { filesToTree, loadBidsIgnore } from './filetree.ts'
 import { FileIgnoreRules } from './ignore.ts'
 import { hashDirLower, parseAnnexKey, resolveAnnexedFile } from './repo.ts'
@@ -138,13 +144,76 @@ export class AnnexedGitFileOpener implements FileOpener {
 
 const MAX_SYMLINK_DEPTH = 10
 
+type SymlinkResolution =
+  | { kind: 'file'; opener: GitFileOpener | AnnexedGitFileOpener }
+  | { kind: 'unresolved'; reason: SymlinkReason }
+
+/**
+ * Resolve a target path relative to a directory inside a git tree.
+ *
+ * Walks segments explicitly so we can distinguish paths that would escape
+ * the repository root from paths that stay inside. Returns null for
+ * absolute targets or any relative target that pops above index 0.
+ */
+function resolveInTree(dir: string, target: string): string | null {
+  if (target.startsWith('/')) return null
+  const joined = (dir ? dir.split('/') : []).concat(target.split('/'))
+  const out: string[] = []
+  for (const seg of joined) {
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      if (out.length === 0) return null
+      out.pop()
+    } else {
+      out.push(seg)
+    }
+  }
+  return out.join('/')
+}
+
+/**
+ * Walk prefixes of a resolved path looking for a gitlink entry (submodule).
+ * Returns true as soon as any prefix tree contains an entry matching the
+ * next segment with type 'commit'. Returns false if the walk completes
+ * without seeing a gitlink, or if any prefix lookup itself throws.
+ */
+async function ancestorIsSubmodule(
+  resolvedPath: string,
+  commitOid: string,
+  gitOptions: GitOptions,
+): Promise<boolean> {
+  const segments = resolvedPath.split('/').filter((s) => s !== '')
+  let prefix = ''
+  for (const segment of segments) {
+    try {
+      const parentObj = await git.readObject({
+        oid: commitOid,
+        filepath: prefix,
+        ...gitOptions,
+      })
+      if (parentObj.type !== 'tree') return false
+      // The tree type exposes `entries` as an array of { mode, path, oid, type }.
+      // deno-lint-ignore no-explicit-any
+      const entries = (parentObj as unknown as { object: { entries: any[] } }).object.entries
+      const match = entries.find((e: { path: string }) => e.path === segment)
+      if (!match) return false
+      if (match.type === 'commit') return true
+      if (match.type !== 'tree') return false
+      prefix = prefix === '' ? segment : `${prefix}/${segment}`
+    } catch {
+      return false
+    }
+  }
+  return false
+}
+
 /**
  * Resolve a non-annex symlink within the git tree.
  *
- * Uses the symlink map (collected during the walk) to follow chains of symlinks
- * up to MAX_SYMLINK_DEPTH, then reads the final target blob from the commit tree.
- * Returns a FileOpener for the resolved target, or undefined if the target
- * cannot be resolved (outside tree, broken link, or cycle).
+ * Returns a file opener for in-tree blob targets, an annex opener when the
+ * chain terminates in an annex key, or an unresolved verdict with a reason
+ * code for broken, cyclic, out-of-tree, submodule-traversing, or
+ * directory-target symlinks.
  */
 async function resolveSymlinkInTree(
   filepath: string,
@@ -154,50 +223,64 @@ async function resolveSymlinkInTree(
   gitOptions: GitOptions,
   symlinkMap: Map<string, string>,
   preferredRemote?: string,
-): Promise<GitFileOpener | AnnexedGitFileOpener | undefined> {
+): Promise<SymlinkResolution> {
   let currentTarget = target
   let currentDir = posix.dirname(filepath)
 
   for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth++) {
-    // Resolve relative target against the current directory
-    const resolvedPath = posix.resolve('/' + currentDir, currentTarget).slice(1)
+    const resolvedPath = resolveInTree(currentDir, currentTarget)
+    if (resolvedPath === null) {
+      return { kind: 'unresolved', reason: 'out-of-tree' }
+    }
 
-    // Check if the resolved path is another symlink we saw during the walk
     const nextTarget = symlinkMap.get(resolvedPath)
     if (nextTarget !== undefined) {
-      // It's a symlink — check if it's an annex pointer first
       const annexParsed = parseAnnexKey(nextTarget)
       if (annexParsed !== null) {
-        return new AnnexedGitFileOpener(
-          annexParsed.key,
-          annexParsed.size,
-          gitdir,
-          gitOptions,
-          preferredRemote,
-        )
+        return {
+          kind: 'file',
+          opener: new AnnexedGitFileOpener(
+            annexParsed.key,
+            annexParsed.size,
+            gitdir,
+            gitOptions,
+            preferredRemote,
+          ),
+        }
       }
-      // Follow the chain
       currentDir = posix.dirname(resolvedPath)
       currentTarget = nextTarget
       continue
     }
 
-    // Not a symlink — try to read the blob from the tree
+    let obj: Awaited<ReturnType<typeof git.readObject>>
     try {
-      const { oid, blob } = await git.readBlob({
+      obj = await git.readObject({
         oid: commitOid,
         filepath: resolvedPath,
         ...gitOptions,
       })
-      return new GitFileOpener(oid, blob.length, gitOptions)
     } catch {
-      // Target does not exist in the tree
-      return undefined
+      if (await ancestorIsSubmodule(resolvedPath, commitOid, gitOptions)) {
+        return { kind: 'unresolved', reason: 'submodule' }
+      }
+      return { kind: 'unresolved', reason: 'broken' }
     }
+
+    if (obj.type === 'tree') {
+      return { kind: 'unresolved', reason: 'directory-unsupported' }
+    }
+    if (obj.type === 'blob') {
+      const { blob } = await git.readBlob({ oid: obj.oid, ...gitOptions })
+      return {
+        kind: 'file',
+        opener: new GitFileOpener(obj.oid, blob.length, gitOptions),
+      }
+    }
+    return { kind: 'unresolved', reason: 'broken' }
   }
 
-  // Exceeded max depth — likely a cycle
-  return undefined
+  return { kind: 'unresolved', reason: 'cycle' }
 }
 
 /**
@@ -331,8 +414,10 @@ export async function readGitTree(
     )
   }
 
+  const unresolvedLinks: UnresolvedLink[] = []
+
   for (const { filepath, target } of deferredSymlinks) {
-    const opener = await resolveSymlinkInTree(
+    const result = await resolveSymlinkInTree(
       filepath,
       target,
       resolvedOid,
@@ -341,11 +426,16 @@ export async function readGitTree(
       symlinkMap,
       preferredRemote,
     )
-    if (opener) {
-      const file = new BIDSFile('/' + filepath, opener, ignore)
-      files.push(file)
+    if (result.kind === 'file') {
+      files.push(new BIDSFile('/' + filepath, result.opener, ignore))
+    } else {
+      unresolvedLinks.push({
+        path: '/' + filepath,
+        target,
+        reason: result.reason,
+      })
     }
   }
 
-  return loadBidsIgnore(filesToTree(files, ignore), ignore)
+  return loadBidsIgnore(filesToTree(files, ignore, unresolvedLinks), ignore)
 }

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -6,7 +6,7 @@
  * readGitTree() to walk a ref and build a FileTree.
  */
 import { default as git, TREE } from 'isomorphic-git'
-import type { WalkerEntry } from 'isomorphic-git'
+import type { ParsedTreeObject, WalkerEntry } from 'isomorphic-git'
 import fs from 'node:fs'
 import * as posix from '@std/path/posix'
 import { join } from '@std/path'
@@ -197,10 +197,9 @@ async function ancestorIsSubmodule(
         ...gitOptions,
       })
       if (parentObj.type !== 'tree') return false
-      // isomorphic-git `ParsedTreeObject` exposes `object` as `TreeEntry[]`, with TreeEntry being an object with fields { mode, path, oid, type }.
-      // deno-lint-ignore no-explicit-any
-      const entries = (parentObj as unknown as { object: { entries: any[] } }).object.entries
-      const match = entries.find((e: { path: string }) => e.path === segment)
+      // isomorphic-git `ParsedTreeObject` exposes `object` as `Array<{ mode, path, oid, type }>`.
+      const children = (parentObj as ParsedTreeObject).object
+      const match = children.find((e: { path: string }) => e.path === segment)
       if (!match) return false
       if (match.type === 'commit') return true
       if (match.type !== 'tree') return false

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -113,8 +113,8 @@ export class AnnexedGitFileOpener implements FileOpener {
       this.#key,
     )
     try {
-      await Deno.stat(localPath)
-      this.#delegate = new FsFileOpener('', localPath)
+      const fileInfo = await Deno.stat(localPath)
+      this.#delegate = new FsFileOpener('', localPath, fileInfo)
       return this.#delegate
     } catch {
       // Local object not present; fall through to remote resolution

--- a/src/files/repo.ts
+++ b/src/files/repo.ts
@@ -187,21 +187,12 @@ export function parseAnnexKey(target: string): { key: string; size: number } | n
   return { key, size }
 }
 
-export async function parseAnnexedFile(
-  path: string,
-): Promise<{ key: string; size: number; gitdir: string }> {
-  const target = await Deno.readLink(path)
-  const dir = dirname(target)
-
-  const dirs = dir.split(SEPARATOR_PATTERN)
-  const gitdir = join(dirname(path), ...dirs.slice(0, dirs.indexOf('.git') + 1))
-
-  const parsed = parseAnnexKey(target)
-  if (!parsed) {
-    throw new Error(`Could not parse annex key from symlink target: ${target}`)
-  }
-
-  return { key: parsed.key, size: parsed.size, gitdir }
+/**
+ * Extract a git directory from the path and target of a git-annex link
+ */
+export function gitdirFromLink(path: string, target: string): string {
+  const dirs = dirname(target).split(SEPARATOR_PATTERN)
+  return join(dirname(path), ...dirs.slice(0, dirs.indexOf('.git') + 1))
 }
 
 /**

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -212,6 +212,26 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'error',
     reason: 'File encoding is not valid UTF-8.',
   },
+  SYMLINK_BROKEN: {
+    severity: 'error',
+    reason: 'Symbolic link target does not exist.',
+  },
+  SYMLINK_CYCLE: {
+    severity: 'error',
+    reason: 'Symbolic link chain contains a cycle or exceeds maximum depth.',
+  },
+  SYMLINK_OUT_OF_TREE: {
+    severity: 'error',
+    reason: 'Symbolic link target escapes the repository root.',
+  },
+  SYMLINK_IN_SUBMODULE: {
+    severity: 'warning',
+    reason: 'Symbolic link target lies within an uninitialized git submodule.',
+  },
+  SYMLINK_DIRECTORY_UNSUPPORTED: {
+    severity: 'warning',
+    reason: 'Symbolic link to a directory is not yet supported when reading from a git tree.',
+  },
 }
 
 export const nonSchemaIssues = { ...bidsIssues }

--- a/src/schema/walk.test.ts
+++ b/src/schema/walk.test.ts
@@ -4,6 +4,14 @@ import { walkFileTree } from './walk.ts'
 import { simpleDataset, simpleDatasetFileCount } from '../tests/simple-dataset.ts'
 import { pathsToTree } from '../files/filetree.test.ts'
 import { loadSchema } from '../setup/loadSchema.ts'
+import type { UnresolvedLink } from '../types/filetree.ts'
+import { FileTree } from '../types/filetree.ts'
+import { FileIgnoreRules } from '../files/ignore.ts'
+
+// Helper: build a minimal BIDSContextDataset wrapping a tree.
+function datasetFor(tree: FileTree): BIDSContextDataset {
+  return new BIDSContextDataset({ tree })
+}
 
 Deno.test('file tree walking', async (t) => {
   const schema = await loadSchema()
@@ -53,4 +61,49 @@ Deno.test('file tree walking', async (t) => {
       'visited file count does not match expected value',
     )
   })
+})
+
+Deno.test('walkFileTree emits SYMLINK_BROKEN for a broken link', async () => {
+  const tree = new FileTree('/', '/')
+  tree.links.push({ path: '/broken', target: '../nope', reason: 'broken' })
+  const ds = datasetFor(tree)
+
+  // Drain the walker so link issues are emitted.
+  for await (const _ of walkFileTree(ds)) { /* consume */ }
+
+  const symlinkIssues = ds.issues.get({ code: 'SYMLINK_BROKEN' })
+  assertEquals(symlinkIssues.length, 1)
+  assertEquals(symlinkIssues[0].location, '/broken')
+})
+
+Deno.test('walkFileTree honours .bidsignore when reporting links', async () => {
+  const rules = new FileIgnoreRules(['ignored/**'])
+  const tree = new FileTree('/', '/', undefined, rules)
+  tree.links.push({ path: '/ignored/broken', target: '../nope', reason: 'broken' })
+  const ds = datasetFor(tree)
+
+  for await (const _ of walkFileTree(ds)) { /* consume */ }
+
+  assertEquals(ds.issues.get({ code: 'SYMLINK_BROKEN' }).length, 0)
+})
+
+Deno.test('walkFileTree emits one issue per link with the correct code', async () => {
+  const tree = new FileTree('/', '/')
+  const cases: UnresolvedLink[] = [
+    { path: '/a', target: 't1', reason: 'broken' },
+    { path: '/b', target: 't2', reason: 'cycle' },
+    { path: '/c', target: 't3', reason: 'out-of-tree' },
+    { path: '/d', target: 't4', reason: 'submodule' },
+    { path: '/e', target: 't5', reason: 'directory-unsupported' },
+  ]
+  for (const link of cases) tree.links.push(link)
+  const ds = datasetFor(tree)
+
+  for await (const _ of walkFileTree(ds)) { /* consume */ }
+
+  assertEquals(ds.issues.get({ code: 'SYMLINK_BROKEN' }).length, 1)
+  assertEquals(ds.issues.get({ code: 'SYMLINK_CYCLE' }).length, 1)
+  assertEquals(ds.issues.get({ code: 'SYMLINK_OUT_OF_TREE' }).length, 1)
+  assertEquals(ds.issues.get({ code: 'SYMLINK_IN_SUBMODULE' }).length, 1)
+  assertEquals(ds.issues.get({ code: 'SYMLINK_DIRECTORY_UNSUPPORTED' }).length, 1)
 })

--- a/src/schema/walk.ts
+++ b/src/schema/walk.ts
@@ -1,10 +1,19 @@
 import { BIDSContext, type BIDSContextDataset } from './context.ts'
-import { BIDSFile, type FileTree } from '../types/filetree.ts'
+import { BIDSFile, type FileTree, type SymlinkReason } from '../types/filetree.ts'
 import { NullFileOpener } from '../files/openers.ts'
 import { loadTSV } from '../files/tsv.ts'
 import { loadJSON } from '../files/json.ts'
 import { readBytes, readText } from '../files/access.ts'
+import type { bidsIssues } from '../issues/list.ts'
 import { queuedAsyncIterator } from '../utils/queue.ts'
+
+const REASON_TO_CODE: Record<SymlinkReason, keyof typeof bidsIssues> = {
+  'broken': 'SYMLINK_BROKEN',
+  'cycle': 'SYMLINK_CYCLE',
+  'out-of-tree': 'SYMLINK_OUT_OF_TREE',
+  'submodule': 'SYMLINK_IN_SUBMODULE',
+  'directory-unsupported': 'SYMLINK_DIRECTORY_UNSUPPORTED',
+}
 
 function* quickWalk(dir: FileTree): Generator<BIDSFile> {
   for (const file of dir.files) {
@@ -32,6 +41,13 @@ async function* _walkFileTree(
   fileTree: FileTree,
   dsContext: BIDSContextDataset,
 ): AsyncIterable<BIDSContext | CleanupFunction> {
+  for (const link of fileTree.links) {
+    if (fileTree.isPathIgnored(link.path)) continue
+    dsContext.issues.add({
+      code: REASON_TO_CODE[link.reason],
+      location: link.path,
+    })
+  }
   for (const file of fileTree.files) {
     if (file.ignored) {
       continue

--- a/src/schema/walk.ts
+++ b/src/schema/walk.ts
@@ -46,6 +46,7 @@ async function* _walkFileTree(
     dsContext.issues.add({
       code: REASON_TO_CODE[link.reason],
       location: link.path,
+      issueMessage: `Target: ${link.target}`,
     })
   }
   for (const file of fileTree.files) {

--- a/src/schema/walk.ts
+++ b/src/schema/walk.ts
@@ -46,7 +46,7 @@ async function* _walkFileTree(
     dsContext.issues.add({
       code: REASON_TO_CODE[link.reason],
       location: link.path,
-      issueMessage: `Target: ${link.target}`,
+      issueMessage: `Symlink target: ${link.target}`,
     })
   }
   for (const file of fileTree.files) {

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -8,6 +8,19 @@ export interface FileOpener {
   readBytes: (size: number, offset?: number) => Promise<Uint8Array<ArrayBuffer>>
 }
 
+export type SymlinkReason =
+  | 'broken'
+  | 'cycle'
+  | 'submodule'
+  | 'out-of-tree'
+  | 'directory-unsupported'
+
+export interface UnresolvedLink {
+  path: string
+  target: string
+  reason: SymlinkReason
+}
+
 export class BIDSFile {
   name: string
   path: string
@@ -72,6 +85,7 @@ export class FileTree {
   name: string
   files: BIDSFile[]
   directories: FileTree[]
+  links: UnresolvedLink[]
   viewed: boolean = false
   #parent?: WeakRef<FileTree>
   #ignore: FileIgnoreRules
@@ -80,6 +94,7 @@ export class FileTree {
     this.path = path
     this.files = []
     this.directories = []
+    this.links = []
     this.name = name
     this.parent = parent
     this.#ignore = ignore ?? new FileIgnoreRules([])

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -113,6 +113,10 @@ export class FileTree {
     return this.#ignore.test(this.path)
   }
 
+  isPathIgnored(path: string): boolean {
+    return this.#ignore.test(path)
+  }
+
   _get(parts: string[]): BIDSFile | FileTree | undefined {
     if (parts.length === 0) {
       return undefined


### PR DESCRIPTION
This introduces five new error codes:

| code | severity | description|
|--|--|--|
| SYMLINK_BROKEN | error | Symbolic link target does not exist. |
| SYMLINK_CYCLE | error | Symbolic link chain contains a cycle or exceeds maximum depth |
| SYMLINK_OUT_OF_TREE | error | Symbolic link target escapes the repository root. |
| SYMLINK_IN_SUBMODULE | warning | Symbolic link target lies within an uninitialized git submodule. |
| SYMLINK_DIRECTORY_UNSUPPORTED |warning | Symbolic link to a directory is not yet supported when reading from a git tree. |

Broken symlinks and symlink cycles are a general problem on the filesystem or in a git tree. (Annex keys are not considered broken.) Out-of-tree symlinks are considered an error for git trees but not filesystem crawls. Symlinks in submodules are a problem for git trees; for filesystem crawls, this is a subset of broken symlink.

The last one is a placeholder to keep the scope of this PR a little smaller. Directories are supported for filesystem crawls, but handling them correctly in git will require some additional thought.

This fixes #374, which could have been triggering either of two independent bugs in symlink resolution.