### PR TITLE
feat: Implement directory symlinks in git and verify equivalence to filesystem

### DIFF
--- a/changelog.d/20260414_141659_markiewicz_git_dir_symlink_grafting.md
+++ b/changelog.d/20260414_141659_markiewicz_git_dir_symlink_grafting.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support symlinks to directories in git tree validation.

--- a/deno.lock
+++ b/deno.lock
@@ -40,6 +40,7 @@
     "npm:hash-wasm@^4.12.0": "4.12.0",
     "npm:hed-validator@~4.1.4": "4.1.4",
     "npm:ignore@^7.0.5": "7.0.5",
+    "npm:isomorphic-git@1.37.4": "1.37.4",
     "npm:isomorphic-git@^1.37.4": "1.37.4",
     "npm:marked@^17.0.5": "17.0.5",
     "npm:supports-hyperlinks@^4.4.0": "4.4.0"

--- a/docs/dev/discussion/2026-04-symlink_handling.md
+++ b/docs/dev/discussion/2026-04-symlink_handling.md
@@ -16,8 +16,11 @@ PR [#380](https://github.com/bids-standard/bids-validator/pull/380):
   directory target) are recorded on `FileTree.links` and surfaced as
   `SYMLINK_*` issues during validation, gated by `.bidsignore`.
 
-Directory-symlink grafting in the git tree remains deferred (see Design
-Question 5 and the "directory-unsupported" reason on `UnresolvedLink`).
+Directory-symlink grafting in the git tree is now implemented on branch
+`feat/git-dir-symlink-grafting`. See
+`2026-04-git_directory_symlink_grafting.md` for the design and the set
+of cross-backend tests that pin down behavioral parity with the work
+tree.
 
 ## Problem
 

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -386,7 +386,7 @@ Deno.test(
       await run(['git', '-C', srcPath, 'config', 'user.name', 'Test'])
       await Deno.writeTextFile(join(srcPath, 'data.txt'), 'bare test')
       await run(['git', '-C', srcPath, 'add', '-A'])
-      await run(['git', '-C', srcPath, 'commit', '-m', 'init'])
+      await run(['git', '-C', srcPath, 'commit', '--no-gpg-sign', '-m', 'init'])
       await run(['git', 'clone', '--bare', srcPath, barePath])
       const tree = await readGitTree(barePath, 'HEAD')
       const data = tree.get('data.txt')

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -11,51 +11,10 @@ import { readFileTree } from './deno.ts'
 import { validate } from '../validators/bids.ts'
 import type { BIDSFile, FileTree } from '../types/filetree.ts'
 import { FileIgnoreRules } from './ignore.ts'
+import { capture, hasGit, hasGitAnnex, isWindows, run, withRepo } from './utils.test.ts'
 
 const REPO_URL = 'https://github.com/openneurodatasets/ds000001.git'
 const REF = '1.0.0'
-
-async function commandExists(cmd: string): Promise<boolean> {
-  try {
-    const proc = new Deno.Command(cmd, { args: ['--help'], stdout: 'null', stderr: 'null' })
-    const { success } = await proc.output()
-    return success
-  } catch {
-    return false
-  }
-}
-
-const hasGit = await commandExists('git')
-const isWindows = Deno.build.os === 'windows'
-const hasGitAnnex = await commandExists('git-annex')
-
-async function run(cmd: string[]): Promise<void> {
-  const proc = new Deno.Command(cmd[0], {
-    args: cmd.slice(1),
-    stdout: 'piped',
-    stderr: 'piped',
-  })
-  const status = await proc.output()
-  if (!status.success) {
-    const stdout = new TextDecoder().decode(status.stdout).trim()
-    const stderr = new TextDecoder().decode(status.stderr).trim()
-    console.error(`Command failed: ${cmd.join(' ')}\n\tstdout: ${stdout}\n\tstderr: ${stderr}`)
-    throw new Error(`Command failed: ${cmd.join(' ')}`)
-  }
-}
-
-async function capture(cmd: string[]): Promise<string> {
-  const proc = new Deno.Command(cmd[0], {
-    args: cmd.slice(1),
-    stdout: 'piped',
-    stderr: 'inherit',
-  })
-  const output = await proc.output()
-  if (!output.success) {
-    throw new Error(`Command failed: ${cmd.join(' ')}`)
-  }
-  return new TextDecoder().decode(output.stdout).trim()
-}
 
 async function setupRepo({ repoPath, bare }: { repoPath: string; bare: boolean }): Promise<void> {
   await run(['git', 'clone', '-b', REF, REPO_URL, repoPath, ...(bare ? ['--bare'] : [])])
@@ -148,30 +107,6 @@ Deno.test(
 // ---------------------------------------------------------------------------
 // Lightweight symlink resolution tests
 // ---------------------------------------------------------------------------
-
-/**
- * Create a temporary git repo, run a setup callback to populate it,
- * commit everything, then run a test callback with the repo path.
- * Cleans up the temp directory in `finally`.
- */
-async function withRepo(
-  setup: (repoPath: string) => Promise<void>,
-  test: (repoPath: string) => Promise<void>,
-): Promise<void> {
-  const tmpDir = await Deno.makeTempDir()
-  try {
-    await run(['git', 'init', tmpDir])
-    await run(['git', '-C', tmpDir, 'config', 'user.email', 'test@test.com'])
-    await run(['git', '-C', tmpDir, 'config', 'user.name', 'Test'])
-    await setup(tmpDir)
-    await run(['git', '-C', tmpDir, 'add', '-A'])
-    await run(['git', '-C', tmpDir, 'commit', '-m', 'init'])
-    await test(tmpDir)
-  } finally {
-    await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()
-    await Deno.remove(tmpDir, { recursive: true })
-  }
-}
 
 Deno.test(
   {

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -503,3 +503,44 @@ Deno.test(
     )
   },
 )
+
+Deno.test(
+  {
+    name: 'readGitTree: submodule cannot (yet) be descended',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (childRepo) => {
+        await Deno.writeTextFile(join(childRepo, 'a.txt'), 'content')
+      },
+      async (childRepo) => {
+        await withRepo(
+          async (repo) => {
+            await run([
+              'git',
+              '-C',
+              repo,
+              '-c',
+              'protocol.file.allow=always',
+              'submodule',
+              'add',
+              childRepo,
+              'submod',
+            ])
+            await run(['ln', '-s', 'submod/a.txt', join(repo, 'a.txt')])
+            await run(['git', '-C', repo, 'commit', '-a', '--no-gpg-sign', '-m', 'add submodule'])
+          },
+          async (repo) => {
+            const tree = await readGitTree(repo)
+            assertEquals(tree.get('a.png'), undefined, 'a.png must not be in files')
+            assertEquals(tree.links.length, 1)
+            assertEquals(tree.links[0].reason, 'submodule')
+          },
+        )
+      },
+    )
+  },
+)

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -454,7 +454,7 @@ Deno.test(
 
 Deno.test(
   {
-    name: 'readGitTree: symlink to a committed directory is directory-unsupported',
+    name: 'readGitTree: in-tree directory symlink is grafted',
     ignore: !hasGit || isWindows,
     sanitizeResources: false,
     sanitizeOps: false,
@@ -468,10 +468,15 @@ Deno.test(
       },
       async (repo) => {
         const tree = await readGitTree(repo)
-        assertEquals(tree.get('linked-dir'), undefined, 'linked-dir must not be in files')
+        const original = tree.get('real-dir/inside.txt') as BIDSFile
+        const grafted = tree.get('linked-dir/inside.txt') as BIDSFile
+        assertExists(original, 'real-dir/inside.txt should be in tree')
+        assertExists(grafted, 'linked-dir/inside.txt should be in tree')
+        assertEquals(await original.text(), 'content')
+        assertEquals(await grafted.text(), 'content')
+        // No unresolved 'directory-unsupported' links any more.
         const dirLinks = tree.links.filter((l) => l.reason === 'directory-unsupported')
-        assertEquals(dirLinks.length, 1)
-        assertEquals(dirLinks[0].path, '/linked-dir')
+        assertEquals(dirLinks.length, 0)
       },
     )
   },

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -474,9 +474,6 @@ Deno.test(
         assertExists(grafted, 'linked-dir/inside.txt should be in tree')
         assertEquals(await original.text(), 'content')
         assertEquals(await grafted.text(), 'content')
-        // No unresolved 'directory-unsupported' links any more.
-        const dirLinks = tree.links.filter((l) => l.reason === 'directory-unsupported')
-        assertEquals(dirLinks.length, 0)
       },
     )
   },

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -13,6 +13,7 @@ import {
   BIDSFile,
   type FileOpener,
   type FileTree,
+  type SymlinkReason,
   type UnresolvedLink,
 } from '../types/filetree.ts'
 import { filesToTree, loadBidsIgnore } from './filetree.ts'
@@ -215,11 +216,8 @@ export async function readGitTree(
 
         // Directories
         if (entryType === 'tree') {
-          // The root entry '.' must always be walked
-          if (filepath === '.') return undefined
-          // Null prevents walk from descending
-          if (prune && prune.test('/' + filepath)) return null
-          return undefined
+          // Null prevents walk from descending, anything but root may be pruned
+          return filepath !== '.' && prune?.test('/' + filepath) ? null : undefined
         }
 
         // Only process blobs
@@ -241,14 +239,9 @@ export async function readGitTree(
           const target = new TextDecoder().decode(content)
           // Record all symlinks so chain resolution can follow through them
           symlinkMap.set(filepath, target)
-          const annexParsed = parseAnnexKey(target)
-          if (annexParsed !== null) {
-            opener = new AnnexedGitFileOpener(
-              annexParsed.key,
-              annexParsed.size,
-              gitOptions,
-              preferredRemote,
-            )
+          const { key, size } = parseAnnexKey(target) ?? {} as { key?: string; size: number }
+          if (key) {
+            opener = new AnnexedGitFileOpener(key, size, gitOptions, preferredRemote)
           } else {
             // Non-annex symlink — defer resolution until walk completes
             deferredSymlinks.push({ filepath, target })
@@ -283,62 +276,38 @@ export async function readGitTree(
     const budget: FollowBudget = { remaining: MAX_SYMLINK_FOLLOWS }
     const verdict = await resolveSymlink(filepath, target, source, budget)
 
-    switch (verdict.kind) {
-      case 'file-blob':
-        files.push(
-          new BIDSFile(
-            '/' + filepath,
-            new GitFileOpener(verdict.oid, verdict.size, verdict.source.gitOptions),
-            ignore,
-          ),
-        )
-        break
-
-      case 'annex':
-        files.push(
-          new BIDSFile(
-            '/' + filepath,
-            new AnnexedGitFileOpener(
-              verdict.key,
-              verdict.size,
-              verdict.source.gitOptions,
-              verdict.source.preferredRemote,
-            ),
-            ignore,
-          ),
-        )
-        break
-
-      case 'tree': {
-        // graftTree manages the visited set itself via add/delete, so we
-        // pass an empty Set per top-level graft. The shared `budget` is
-        // the same FollowBudget allocated for this iteration so nested
-        // resolveSymlink calls inside the walk share its countdown.
-        const visited = new Set<string>()
-        const graft = await graftTree(
-          '/' + filepath,
-          verdict,
-          budget,
-          visited,
-          prune,
-        )
-        files.push(...graft.files)
-        unresolvedLinks.push(...graft.links)
-        break
+    if (verdict.kind === 'tree') {
+      const graft = await graftTree('/' + filepath, verdict, budget, new Set(), prune)
+      files.push(...graft.files)
+      unresolvedLinks.push(...graft.links)
+      continue
+    }
+    // Identify files and failures
+    const outcome = ((): FileOpener | SymlinkReason => {
+      switch (verdict.kind) {
+        case 'file-blob':
+          return new GitFileOpener(verdict.oid, verdict.size, verdict.source.gitOptions)
+        case 'annex': {
+          const { key, size, source: { gitOptions, preferredRemote } } = verdict
+          return new AnnexedGitFileOpener(key, size, gitOptions, preferredRemote)
+        }
+        case 'submodule-boundary':
+          return 'submodule'
+        case 'unresolved':
+          return verdict.reason
+        // deno-coverage-ignore-start
+        default: {
+          const _exhaustive: never = verdict
+          throw new Error(`Unhandled ResolveVerdict kind: ${(verdict as { kind: string }).kind}`)
+          // deno-coverage-ignore-stop
+        }
       }
-
-      case 'submodule-boundary':
-        unresolvedLinks.push({ path: '/' + filepath, target, reason: 'submodule' })
-        break
-
-      case 'unresolved':
-        unresolvedLinks.push({ path: '/' + filepath, target, reason: verdict.reason })
-        break
-
-      default: {
-        const _exhaustive: never = verdict
-        throw new Error(`Unhandled ResolveVerdict kind: ${(verdict as { kind: string }).kind}`)
-      }
+    })()
+    // Record files and failures
+    if (typeof outcome !== 'string') {
+      files.push(new BIDSFile('/' + filepath, outcome, ignore))
+    } else {
+      unresolvedLinks.push({ path: '/' + filepath, target, reason: outcome })
     }
   }
 

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -331,6 +331,11 @@ export async function readGitTree(
       case 'unresolved':
         unresolvedLinks.push({ path: '/' + filepath, target, reason: verdict.reason })
         break
+
+      default: {
+        const _exhaustive: never = verdict
+        throw new Error(`Unhandled ResolveVerdict kind: ${(verdict as { kind: string }).kind}`)
+      }
     }
   }
 

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -281,7 +281,7 @@ export async function readGitTree(
 
   for (const { filepath, target } of deferredSymlinks) {
     const budget: FollowBudget = { remaining: MAX_SYMLINK_FOLLOWS }
-    const verdict = await resolveSymlink(filepath, target, source, budget, prune)
+    const verdict = await resolveSymlink(filepath, target, source, budget)
 
     switch (verdict.kind) {
       case 'file-blob':

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -211,8 +211,8 @@ export async function readGitTree(
 
         const entryType = await entry.type()
 
-        // TODO: Handle submodules (entryType === 'commit')
-        if (entryType === 'commit') return null
+        // TODO: Handle submodules
+        // if (entryType === 'commit') {}
 
         // Directories
         if (entryType === 'tree') {

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -20,11 +20,7 @@ import { FileIgnoreRules } from './ignore.ts'
 import { hashDirLower, parseAnnexKey, resolveAnnexedFile } from './repo.ts'
 import { FsFileOpener, HTTPOpener, NullFileOpener } from './openers.ts'
 import { streamFromUint8Array } from './streams.ts'
-import {
-  // graftTree is imported in Task 6 when the tree verdict is wired up.
-  MAX_SYMLINK_FOLLOWS,
-  resolveSymlink,
-} from './gitResolver.ts'
+import { graftTree, MAX_SYMLINK_FOLLOWS, resolveSymlink } from './gitResolver.ts'
 import type { FollowBudget, GitOptions, TreeSource } from './gitResolver.ts'
 
 export class GitFileOpener implements FileOpener {
@@ -313,16 +309,23 @@ export async function readGitTree(
         )
         break
 
-      case 'tree':
-        // Directory grafting lands in Task 6. Until then, keep the
-        // pre-change behavior so the existing directory-unsupported test
-        // passes.
-        unresolvedLinks.push({
-          path: '/' + filepath,
-          target,
-          reason: 'directory-unsupported',
-        })
+      case 'tree': {
+        // graftTree manages the visited set itself via add/delete, so we
+        // pass an empty Set per top-level graft. The shared `budget` is
+        // the same FollowBudget allocated for this iteration so nested
+        // resolveSymlink calls inside the walk share its countdown.
+        const visited = new Set<string>()
+        const graft = await graftTree(
+          '/' + filepath,
+          verdict,
+          budget,
+          visited,
+          prune,
+        )
+        files.push(...graft.files)
+        unresolvedLinks.push(...graft.links)
         break
+      }
 
       case 'submodule-boundary':
         unresolvedLinks.push({ path: '/' + filepath, target, reason: 'submodule' })

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -142,6 +142,47 @@ export class AnnexedGitFileOpener implements FileOpener {
 }
 
 /**
+ * Find the gitdir for a repository path, and resolve the requested ref to a commit OID.
+ */
+async function resolveRef(
+  repoPath: string,
+  ref: string,
+): Promise<{ commit: string; gitOptions: GitOptions }> {
+  const dotGitPath = join(repoPath, '.git')
+  let gitdir: string
+  try {
+    const stat = await Deno.stat(dotGitPath)
+    gitdir = stat.isDirectory ? dotGitPath : repoPath
+  } catch {
+    gitdir = repoPath
+  }
+
+  const gitOptions: GitOptions = { fs, gitdir, cache: {} }
+
+  // Resolve HEAD to verify this is a git repository and it has commits.
+  try {
+    const head = await git.resolveRef({ ref: 'HEAD', ...gitOptions })
+    if (ref === 'HEAD') {
+      return { commit: head, gitOptions }
+    }
+  } catch {
+    throw new Error(`Repository ${repoPath} is not a git repository or has no commits`)
+  }
+
+  // Now resolve the requested ref, which may be a branch, tag, or commit SHA
+  try {
+    return { commit: await git.resolveRef({ ref, ...gitOptions }), gitOptions }
+  } catch {
+    // resolveRef doesn't handle abbreviated SHAs; try expandOid
+    try {
+      return { commit: await git.expandOid({ oid: ref, ...gitOptions }), gitOptions }
+    } catch {
+      throw new Error(`Could not resolve ref '${ref}' in ${repoPath}`)
+    }
+  }
+}
+
+/**
  * Walk a git ref and build a FileTree from all blobs found.
  *
  * Uses isomorphic-git walk() with TREE to enumerate files at the given ref,
@@ -153,59 +194,17 @@ export async function readGitTree(
   prune?: FileIgnoreRules,
   preferredRemote?: string,
 ): Promise<FileTree> {
-  const cache = {}
+  const { commit, gitOptions } = await resolveRef(repoPath, ref)
+
   const ignore = new FileIgnoreRules([])
-
-  // Detect gitdir: if repoPath contains .git, use it; otherwise treat as bare
-  const dotGitPath = join(repoPath, '.git')
-  let gitdir: string
-  try {
-    const stat = Deno.statSync(dotGitPath)
-    gitdir = stat.isDirectory ? dotGitPath : repoPath
-  } catch {
-    gitdir = repoPath
-  }
-
-  const gitOptions: GitOptions = { fs, gitdir, cache }
-
-  // Validate the repo and resolve the requested ref, with clear error messages.
-  // We always resolve HEAD first so we can distinguish three cases:
-  //   1. Path is not a git repo at all (NotGitRepository)
-  //   2. Repo exists but has no commits (HEAD → NotFoundError)
-  //   3. Repo has commits but the requested ref doesn't exist
-  let resolvedOid: string
-  try {
-    await git.resolveRef({ ref: 'HEAD', ...gitOptions })
-  } catch (err: unknown) {
-    const code = (err as { code?: string }).code
-    if (code === 'NotGitRepository') {
-      throw new Error(`${repoPath} is not a git repository`)
-    }
-    throw new Error(`Repository ${repoPath} has no commits`)
-  }
-  try {
-    resolvedOid = await git.resolveRef({ ref, ...gitOptions })
-  } catch {
-    // resolveRef doesn't handle abbreviated SHAs; try expandOid
-    try {
-      resolvedOid = await git.expandOid({ oid: ref, ...gitOptions })
-    } catch {
-      throw new Error(`Could not resolve ref '${ref}' in ${repoPath}`)
-    }
-  }
-
   const files: BIDSFile[] = []
-
-  // Map of all symlinks found during the walk (filepath → target)
-  // Used to follow chains of symlinks during deferred resolution
   const symlinkMap = new Map<string, string>()
-  // Deferred symlink entries that need resolution after the walk completes
   const deferredSymlinks: { filepath: string; target: string }[] = []
 
   try {
     await git.walk({
       ...gitOptions,
-      trees: [TREE({ ref: resolvedOid })],
+      trees: [TREE({ ref: commit })],
       map: async (filepath: string, [entry]: Array<WalkerEntry | null>) => {
         if (!entry) return null
 
@@ -263,13 +262,7 @@ export async function readGitTree(
     )
   }
 
-  const source: TreeSource = {
-    commitOid: resolvedOid,
-    gitOptions,
-    symlinkMap,
-    preferredRemote,
-  }
-
+  const source: TreeSource = { commitOid: commit, gitOptions, symlinkMap, preferredRemote }
   const unresolvedLinks: UnresolvedLink[] = []
 
   for (const { filepath, target } of deferredSymlinks) {

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -6,15 +6,13 @@
  * readGitTree() to walk a ref and build a FileTree.
  */
 import { default as git, TREE } from 'isomorphic-git'
-import type { ParsedTreeObject, WalkerEntry } from 'isomorphic-git'
+import type { WalkerEntry } from 'isomorphic-git'
 import fs from 'node:fs'
-import * as posix from '@std/path/posix'
 import { join } from '@std/path'
 import {
   BIDSFile,
   type FileOpener,
   type FileTree,
-  type SymlinkReason,
   type UnresolvedLink,
 } from '../types/filetree.ts'
 import { filesToTree, loadBidsIgnore } from './filetree.ts'
@@ -22,13 +20,12 @@ import { FileIgnoreRules } from './ignore.ts'
 import { hashDirLower, parseAnnexKey, resolveAnnexedFile } from './repo.ts'
 import { FsFileOpener, HTTPOpener, NullFileOpener } from './openers.ts'
 import { streamFromUint8Array } from './streams.ts'
-
-export interface GitOptions {
-  // deno-lint-ignore no-explicit-any
-  fs: any
-  gitdir: string
-  cache: object
-}
+import {
+  // graftTree is imported in Task 6 when the tree verdict is wired up.
+  MAX_SYMLINK_FOLLOWS,
+  resolveSymlink,
+} from './gitResolver.ts'
+import type { FollowBudget, GitOptions, TreeSource } from './gitResolver.ts'
 
 export class GitFileOpener implements FileOpener {
   oid: string
@@ -145,145 +142,6 @@ export class AnnexedGitFileOpener implements FileOpener {
   async readBytes(size: number, offset = 0): Promise<Uint8Array<ArrayBuffer>> {
     return (await this.#resolve()).readBytes(size, offset)
   }
-}
-
-const MAX_SYMLINK_DEPTH = 10
-
-type SymlinkResolution =
-  | { kind: 'file'; opener: GitFileOpener | AnnexedGitFileOpener }
-  | { kind: 'unresolved'; reason: SymlinkReason }
-
-/**
- * Resolve a target path relative to a directory inside a git tree.
- *
- * Walks segments explicitly so we can distinguish paths that would escape
- * the repository root from paths that stay inside. Returns null for
- * absolute targets or any relative target that pops above index 0.
- */
-function resolveInTree(dir: string, target: string): string | null {
-  if (target.startsWith('/')) return null
-  const joined = (dir ? dir.split('/') : []).concat(target.split('/'))
-  const out: string[] = []
-  for (const seg of joined) {
-    if (seg === '' || seg === '.') continue
-    if (seg === '..') {
-      if (out.length === 0) return null
-      out.pop()
-    } else {
-      out.push(seg)
-    }
-  }
-  return out.join('/')
-}
-
-/**
- * Walk prefixes of a resolved path looking for a gitlink entry (submodule).
- * Returns true as soon as any prefix tree contains an entry matching the
- * next segment with type 'commit'. Returns false if the walk completes
- * without seeing a gitlink, or if any prefix lookup itself throws.
- */
-async function ancestorIsSubmodule(
-  resolvedPath: string,
-  commitOid: string,
-  gitOptions: GitOptions,
-): Promise<boolean> {
-  const segments = resolvedPath.split('/').filter((s) => s !== '')
-  let prefix = ''
-  for (const segment of segments) {
-    try {
-      const parentObj = await git.readObject({
-        oid: commitOid,
-        filepath: prefix,
-        ...gitOptions,
-      })
-      if (parentObj.type !== 'tree') return false
-      // isomorphic-git `ParsedTreeObject` exposes `object` as `Array<{ mode, path, oid, type }>`.
-      const children = (parentObj as ParsedTreeObject).object
-      const match = children.find((e: { path: string }) => e.path === segment)
-      if (!match) return false
-      if (match.type === 'commit') return true
-      if (match.type !== 'tree') return false
-      prefix = prefix === '' ? segment : `${prefix}/${segment}`
-    } catch (err: unknown) {
-      if (err && typeof err == 'object' && 'isIsomorphicGitError' in err) return false
-      throw err
-    }
-  }
-  return false
-}
-
-/**
- * Resolve a non-annex symlink within the git tree.
- *
- * Returns a file opener for in-tree blob targets, an annex opener when the
- * chain terminates in an annex key, or an unresolved verdict with a reason
- * code for broken, cyclic, out-of-tree, submodule-traversing, or
- * directory-target symlinks.
- */
-async function resolveSymlinkInTree(
-  filepath: string,
-  target: string,
-  commitOid: string,
-  gitOptions: GitOptions,
-  symlinkMap: Map<string, string>,
-  preferredRemote?: string,
-): Promise<SymlinkResolution> {
-  let currentTarget = target
-  let currentDir = posix.dirname(filepath)
-
-  for (let depth = 0; depth < MAX_SYMLINK_DEPTH; depth++) {
-    const resolvedPath = resolveInTree(currentDir, currentTarget)
-    if (resolvedPath === null) {
-      return { kind: 'unresolved', reason: 'out-of-tree' }
-    }
-
-    const nextTarget = symlinkMap.get(resolvedPath)
-    if (nextTarget !== undefined) {
-      const annexParsed = parseAnnexKey(nextTarget)
-      if (annexParsed !== null) {
-        return {
-          kind: 'file',
-          opener: new AnnexedGitFileOpener(
-            annexParsed.key,
-            annexParsed.size,
-            gitOptions,
-            preferredRemote,
-          ),
-        }
-      }
-      currentDir = posix.dirname(resolvedPath)
-      currentTarget = nextTarget
-      continue
-    }
-
-    let obj: Awaited<ReturnType<typeof git.readObject>>
-    try {
-      obj = await git.readObject({
-        oid: commitOid,
-        filepath: resolvedPath,
-        ...gitOptions,
-      })
-    } catch {
-      if (await ancestorIsSubmodule(resolvedPath, commitOid, gitOptions)) {
-        return { kind: 'unresolved', reason: 'submodule' }
-      }
-      return { kind: 'unresolved', reason: 'broken' }
-    }
-
-    if (obj.type === 'tree') {
-      return { kind: 'unresolved', reason: 'directory-unsupported' }
-    }
-    if (obj.type === 'blob') {
-      const { blob } = await git.readBlob({ oid: obj.oid, ...gitOptions })
-      return {
-        kind: 'file',
-        opener: new GitFileOpener(obj.oid, blob.length, gitOptions),
-      }
-    }
-    return { kind: 'unresolved', reason: 'broken' }
-  }
-
-  return { kind: 'unresolved', reason: 'cycle' }
 }
 
 /**
@@ -416,25 +274,63 @@ export async function readGitTree(
     )
   }
 
+  const source: TreeSource = {
+    commitOid: resolvedOid,
+    gitOptions,
+    symlinkMap,
+    preferredRemote,
+  }
+
   const unresolvedLinks: UnresolvedLink[] = []
 
   for (const { filepath, target } of deferredSymlinks) {
-    const result = await resolveSymlinkInTree(
-      filepath,
-      target,
-      resolvedOid,
-      gitOptions,
-      symlinkMap,
-      preferredRemote,
-    )
-    if (result.kind === 'file') {
-      files.push(new BIDSFile('/' + filepath, result.opener, ignore))
-    } else {
-      unresolvedLinks.push({
-        path: '/' + filepath,
-        target,
-        reason: result.reason,
-      })
+    const budget: FollowBudget = { remaining: MAX_SYMLINK_FOLLOWS }
+    const verdict = await resolveSymlink(filepath, target, source, budget, prune)
+
+    switch (verdict.kind) {
+      case 'file-blob':
+        files.push(
+          new BIDSFile(
+            '/' + filepath,
+            new GitFileOpener(verdict.oid, verdict.size, verdict.source.gitOptions),
+            ignore,
+          ),
+        )
+        break
+
+      case 'annex':
+        files.push(
+          new BIDSFile(
+            '/' + filepath,
+            new AnnexedGitFileOpener(
+              verdict.key,
+              verdict.size,
+              verdict.source.gitOptions,
+              verdict.source.preferredRemote,
+            ),
+            ignore,
+          ),
+        )
+        break
+
+      case 'tree':
+        // Directory grafting lands in Task 6. Until then, keep the
+        // pre-change behavior so the existing directory-unsupported test
+        // passes.
+        unresolvedLinks.push({
+          path: '/' + filepath,
+          target,
+          reason: 'directory-unsupported',
+        })
+        break
+
+      case 'submodule-boundary':
+        unresolvedLinks.push({ path: '/' + filepath, target, reason: 'submodule' })
+        break
+
+      case 'unresolved':
+        unresolvedLinks.push({ path: '/' + filepath, target, reason: verdict.reason })
+        break
     }
   }
 

--- a/src/files/gitResolver.test.ts
+++ b/src/files/gitResolver.test.ts
@@ -1,0 +1,20 @@
+import { assertEquals } from '@std/assert'
+import type { ResolveVerdict, TreeSource } from './gitResolver.ts'
+
+Deno.test('gitResolver: ResolveVerdict union includes every kind', () => {
+  const source: TreeSource = {
+    commitOid: 'abcdef0123456789',
+    // deno-lint-ignore no-explicit-any
+    gitOptions: { fs: {}, gitdir: '/tmp/fake.git', cache: {} } as any,
+    symlinkMap: new Map(),
+  }
+  // Type checks
+  const verdicts: ResolveVerdict[] = [
+    { kind: 'file-blob', oid: 'x', size: 1, source },
+    { kind: 'annex', key: 'k', size: 2, source },
+    { kind: 'tree', treePath: 'p', originalDir: 'd', source },
+    { kind: 'submodule-boundary', mountPath: 'sub', remainder: 'path', source },
+    { kind: 'unresolved', reason: 'broken' },
+  ]
+  assertEquals(verdicts.length, 5)
+})

--- a/src/files/gitResolver.test.ts
+++ b/src/files/gitResolver.test.ts
@@ -1,5 +1,12 @@
 import { assertEquals } from '@std/assert'
+import { join } from '@std/path'
 import type { ResolveVerdict, TreeSource } from './gitResolver.ts'
+import * as posix from '@std/path/posix'
+import { findSubmoduleAncestor } from './gitResolver.ts'
+import { hasGit, isWindows, withRepo } from './utils.test.ts'
+
+type objType = 'tree' | 'blob' | 'commit'
+const linkMode = '120000'
 
 Deno.test('gitResolver: ResolveVerdict union includes every kind', () => {
   const source: TreeSource = {
@@ -18,3 +25,148 @@ Deno.test('gitResolver: ResolveVerdict union includes every kind', () => {
   ]
   assertEquals(verdicts.length, 5)
 })
+
+/**
+ * Types and helpers for fake tree construction in tests.
+ */
+type TreeEntry = { path: string; type: objType; mode?: string }
+
+type FakeEntry =
+  | { type: 'tree'; object: TreeEntry[] }
+  | { type: 'blob'; oid: string; object?: Uint8Array }
+  | { type: 'commit' }
+
+/** Spec for a single blob in the fake tree */
+type ObjSpec = {
+  type: objType
+  path: string
+  content: string
+  mode?: string
+}
+
+/** Create a blob spec. Regular file if no mode; symlink if mode === linkMode */
+function blob(path: string, content: string = 'content', mode?: string): ObjSpec {
+  return { type: 'blob', path, content, mode }
+}
+function submodule(path: string): ObjSpec {
+  return { type: 'commit', path, content: 'commit-hash' }
+}
+
+/**
+ * Build a TreeSource from a flat list of blob specs. Auto-generates the full
+ * tree hierarchy, oids (derived from paths), and byte arrays.
+ */
+function fakeTreeSource(objs: ObjSpec[]): TreeSource {
+  const objects = new Map<string, FakeEntry>()
+  const encoder = new TextEncoder()
+
+  for (const obj of objs) {
+    // Direct lookup
+    if (obj.type === 'blob') {
+      objects.set(
+        obj.path,
+        {
+          type: 'blob' as const,
+          oid: obj.path.replace(/[/.]/g, '-'),
+          object: encoder.encode(obj.content),
+        },
+      )
+    }
+
+    // Populate parent trees
+    let { dir, base } = posix.parse(obj.path)
+    let child: TreeEntry = { path: base, type: obj.type, mode: obj.mode }
+    if (dir == '.') dir = ''
+    let parent = objects.get(dir) as Extract<FakeEntry, { type: 'tree' }> | undefined
+
+    // Create tree entries for children
+    while (!parent) {
+      objects.set(dir, { type: 'tree' as const, object: [child] })
+      ;({ dir, base } = posix.parse(dir))
+      child = { path: base, type: 'tree' as const }
+      if (dir == '.') dir = ''
+      parent = objects.get(dir) as Extract<FakeEntry, { type: 'tree' }> | undefined
+    }
+    // Found existing tree, update with last-created entry
+    parent.object.push(child)
+  }
+
+  // Build symlinkMap from blob specs annotated with linkMode
+  const symlinkMap = new Map<string, string>()
+  for (const { path, content } of objs.filter(({ mode }) => mode === linkMode)) {
+    symlinkMap.set(path, content)
+  }
+
+  return {
+    commitOid: 'fake-commit',
+    // deno-lint-ignore no-explicit-any
+    gitOptions: { fs: {}, gitdir: '/tmp/fake.git', cache: { __fake: objects } } as any,
+    symlinkMap,
+  }
+}
+
+Deno.test('findSubmoduleAncestor: returns null when no gitlink in prefix', async () => {
+  const source = fakeTreeSource([
+    blob('a/b/c'),
+  ])
+  const result = await findSubmoduleAncestor('a/b/missing', source)
+  assertEquals(result, null)
+})
+
+Deno.test('findSubmoduleAncestor: returns the mount path when an ancestor is a gitlink', async () => {
+  const source = fakeTreeSource([
+    submodule('sub'),
+  ])
+  const result = await findSubmoduleAncestor('sub/inner/file.txt', source)
+  assertEquals(result, { mountPath: 'sub', remainder: 'inner/file.txt' })
+})
+
+Deno.test('findSubmoduleAncestor: returns null when prefix walk hits a blob', async () => {
+  const source = fakeTreeSource([
+    blob('a'),
+  ])
+  const result = await findSubmoduleAncestor('a/b', source)
+  assertEquals(result, null)
+})
+
+Deno.test(
+  {
+    name: 'findSubmoduleAncestor: smoke test against a real git repo (no fake)',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        // Create a regular file at a/b/c.txt — NOT a submodule. The test
+        // confirms that findSubmoduleAncestor correctly returns null and
+        // does NOT throw a TypeError from the legacy tree-shape bug.
+        await Deno.mkdir(join(repo, 'a', 'b'), { recursive: true })
+        await Deno.writeTextFile(join(repo, 'a', 'b', 'c.txt'), 'content')
+      },
+      async (repo) => {
+        // Resolve the HEAD commit OID so we use a real commit.
+        const { default: git } = await import('isomorphic-git')
+        const { default: fs } = await import('node:fs')
+        const commitOid = await git.resolveRef({ fs, gitdir: join(repo, '.git'), ref: 'HEAD' })
+
+        const source: TreeSource = {
+          commitOid,
+          // deno-lint-ignore no-explicit-any
+          gitOptions: { fs, gitdir: join(repo, '.git'), cache: {} } as any,
+          symlinkMap: new Map(),
+        }
+
+        // A path that exists but has no submodule ancestor — must return null
+        // without throwing.
+        const resultExisting = await findSubmoduleAncestor('a/b/c.txt', source)
+        assertEquals(resultExisting, null)
+
+        // A path under a missing directory — also must return null, not throw.
+        const resultMissing = await findSubmoduleAncestor('a/nope/x.txt', source)
+        assertEquals(resultMissing, null)
+      },
+    )
+  },
+)

--- a/src/files/gitResolver.test.ts
+++ b/src/files/gitResolver.test.ts
@@ -296,6 +296,19 @@ Deno.test('resolveSymlink: mutual cycle a <-> b returns cycle', async () => {
   assertEquals(verdict, { kind: 'unresolved', reason: 'cycle' })
 })
 
+Deno.test('resolveSymlink: symlink into submodule returns submodule-boundary', async () => {
+  const source = fakeTreeSource([
+    blob('link', 'sub/inner/file.txt', linkMode),
+    submodule('sub'),
+  ])
+  const verdict = await resolveSymlink('link', 'sub/inner/file.txt', source, budget())
+  assertEquals(verdict.kind, 'submodule-boundary')
+  if (verdict.kind === 'submodule-boundary') {
+    assertEquals(verdict.mountPath, 'sub')
+    assertEquals(verdict.remainder, 'inner/file.txt')
+  }
+})
+
 function treeVerdict(
   treePath: string,
   originalDir: string,

--- a/src/files/gitResolver.test.ts
+++ b/src/files/gitResolver.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from '@std/assert'
+import { assertEquals, assertExists, assertObjectMatch } from '@std/assert'
 import { join } from '@std/path'
 import * as posix from '@std/path/posix'
 import type { FollowBudget, ResolveVerdict, TreeSource } from './gitResolver.ts'
@@ -444,4 +444,83 @@ Deno.test('graftTree: dir symlink back into ancestor produces finite recursion',
   assertEquals(cycleLinks.length > 0, true, 'expected at least one cycle link')
   // Sanity: recursion terminates.
   assertEquals(result.files.length < 1000, true, 'recursion did not terminate')
+})
+
+Deno.test('graftTree: handles submodules directly within a grafted directory', async () => {
+  const source = fakeTreeSource([
+    // A directory that contains a file and a submodule
+    blob('real_dir/file.txt'),
+    submodule('real_dir/sub'),
+    // A symlink that points to this directory, which will be grafted
+    blob('view', 'real_dir/', linkMode),
+  ])
+
+  const verdict = await resolveSymlink('view', 'real_dir/', source, budget())
+  assertEquals(verdict.kind, 'tree')
+  if (verdict.kind !== 'tree') return
+
+  const result = await graftTree('/view', verdict, budget(), new Set())
+
+  const paths = result.files.map((f) => f.path)
+  assertEquals(paths, ['/view/file.txt'])
+
+  assertEquals(result.links.length, 1)
+  assertObjectMatch(result.links[0], {
+    path: '/view/sub',
+    reason: 'submodule',
+  })
+})
+
+Deno.test('graftTree: handles nested symlinks pointing into a submodule', async () => {
+  const source = fakeTreeSource([
+    submodule('sub'),
+    blob('real_dir/link_to_sub', '../sub/some/file.txt', linkMode),
+    blob('view', 'real_dir/', linkMode),
+  ])
+
+  const verdict = await resolveSymlink('view', 'real_dir/', source, budget())
+  assertEquals(verdict.kind, 'tree')
+  if (verdict.kind !== 'tree') return
+
+  const result = await graftTree('/view', verdict, budget(), new Set())
+
+  assertEquals(result.files.length, 0)
+  assertEquals(result.links.length, 1)
+  assertObjectMatch(result.links[0], {
+    path: '/view/link_to_sub',
+    target: '../sub/some/file.txt', // Target is the original symlink content
+    reason: 'submodule',
+  })
+})
+
+Deno.test('graftTree: resolves symlink chains to annexed files', async () => {
+  const key = 'MD5E-s1234--d41d8cd98f00b204e9800998ecf8427e.nii.gz'
+  const annexTarget = `../../../.git/annex/objects/xx/yy/${key}/${key}`
+
+  const source = fakeTreeSource([
+    blob('original/deep/location/file.nii.gz', annexTarget, linkMode),
+    // Direct link to annexed file
+    blob('real_dir/alias.nii.gz', '../original/deep/location/file.nii.gz', linkMode),
+    // Indirect link to annexed file
+    blob('real_dir/shallow', '../original/deep/location', linkMode),
+
+    // Graft real_dir and find both kinds of reference
+    blob('view', 'real_dir', linkMode),
+  ])
+
+  const verdict = await resolveSymlink('view', 'real_dir', source, budget())
+  assertEquals(verdict.kind, 'tree')
+  if (verdict.kind !== 'tree') return
+
+  const result = await graftTree('/view', verdict, budget(), new Set())
+
+  // Assertions
+  assertEquals(result.files.length, 2)
+  const paths = result.files.map((f) => f.path)
+  assertEquals(
+    paths.includes('/view/shallow/file.nii.gz'),
+    true,
+    'expected /view/shallow/file.nii.gz',
+  )
+  assertEquals(paths.includes('/view/alias.nii.gz'), true, 'expected /view/alias.nii.gz')
 })

--- a/src/files/gitResolver.test.ts
+++ b/src/files/gitResolver.test.ts
@@ -1,8 +1,8 @@
 import { assertEquals } from '@std/assert'
 import { join } from '@std/path'
-import type { ResolveVerdict, TreeSource } from './gitResolver.ts'
 import * as posix from '@std/path/posix'
-import { findSubmoduleAncestor } from './gitResolver.ts'
+import type { FollowBudget, ResolveVerdict, TreeSource } from './gitResolver.ts'
+import { findSubmoduleAncestor, resolveSymlink } from './gitResolver.ts'
 import { hasGit, isWindows, withRepo } from './utils.test.ts'
 
 type objType = 'tree' | 'blob' | 'commit'
@@ -170,3 +170,127 @@ Deno.test(
     )
   },
 )
+
+function budget(n = 10): FollowBudget {
+  return { remaining: n }
+}
+
+Deno.test('resolveSymlink: terminal file-blob resolves', async () => {
+  const source = fakeTreeSource([
+    blob('a/foo.txt'),
+    blob('a/b/link', '../foo.txt', linkMode),
+  ])
+
+  const verdict = await resolveSymlink('a/b/link', '../foo.txt', source, budget())
+  assertEquals(verdict.kind, 'file-blob')
+  if (verdict.kind === 'file-blob') {
+    assertEquals(verdict.oid, 'a-foo-txt')
+  }
+})
+
+Deno.test('resolveSymlink: absolute target is out-of-tree', async () => {
+  const source = fakeTreeSource([])
+  const verdict = await resolveSymlink('link', '/etc/passwd', source, budget())
+  assertEquals(verdict, { kind: 'unresolved', reason: 'out-of-tree' })
+})
+
+Deno.test('resolveSymlink: relative escape above root is out-of-tree', async () => {
+  const source = fakeTreeSource([])
+  const verdict = await resolveSymlink('a/link', '../../../etc/passwd', source, budget())
+  assertEquals(verdict, { kind: 'unresolved', reason: 'out-of-tree' })
+})
+
+Deno.test('resolveSymlink: missing target is broken', async () => {
+  const source = fakeTreeSource([
+    blob('a/link', '../nowhere.txt', linkMode),
+  ])
+  const verdict = await resolveSymlink('a/link', '../nowhere.txt', source, budget())
+  assertEquals(verdict, { kind: 'unresolved', reason: 'broken' })
+})
+
+Deno.test('resolveSymlink: terminal tree returns a tree verdict', async () => {
+  const source = fakeTreeSource([
+    blob('real/.gitkeep', ''),
+    blob('linkdir', 'real/', linkMode),
+  ])
+  const verdict = await resolveSymlink('linkdir', 'real/', source, budget())
+  assertEquals(verdict.kind, 'tree')
+  if (verdict.kind === 'tree') {
+    assertEquals(verdict.treePath, 'real')
+    assertEquals(verdict.originalDir, '')
+  }
+})
+
+Deno.test('resolveSymlink: follows a chain of file symlinks', async () => {
+  const source = fakeTreeSource([
+    blob('a', 'b', linkMode),
+    blob('b', 'c', linkMode),
+    blob('c', 'real.txt', linkMode),
+    blob('real.txt'),
+  ])
+  const verdict = await resolveSymlink('a', 'b', source, budget())
+  assertEquals(verdict.kind, 'file-blob')
+  if (verdict.kind === 'file-blob') {
+    assertEquals(verdict.oid, 'real-txt')
+  }
+})
+
+Deno.test('resolveSymlink: terminal chain resolving to an annex key', async () => {
+  const annexKey = 'MD5E-s1234--d41d8cd98f00b204e9800998ecf8427e.nii.gz'
+  const annexTarget = `../.git/annex/objects/xx/yy/${annexKey}/${annexKey}`
+  const source = fakeTreeSource([
+    blob('link', annexTarget, linkMode),
+    blob('alias', 'link', linkMode),
+  ])
+  const verdict = await resolveSymlink('alias', 'link', source, budget())
+  assertEquals(verdict.kind, 'annex')
+  if (verdict.kind === 'annex') {
+    assertEquals(verdict.key, annexKey)
+    assertEquals(verdict.size, 1234)
+  }
+})
+
+Deno.test('resolveSymlink: follows intermediate directory symlink during segment walk', async () => {
+  // Layout (Unix physical-path semantics):
+  //   a/c is a symlink to "../d/e/" (escapes 'a/' to root, then into d/e/)
+  //   a/b/link is a symlink to "../c/file" (pops to 'a', resolves 'a/c' then 'file')
+  //   d/e/file is a regular blob with content
+  const source = fakeTreeSource([
+    blob('a/b/link', '../c/file', linkMode),
+    blob('a/c', '../d/e/', linkMode),
+    blob('d/e/file'),
+  ])
+
+  const verdict = await resolveSymlink('a/b/link', '../c/file', source, budget())
+  assertEquals(verdict.kind, 'file-blob')
+  if (verdict.kind === 'file-blob') {
+    assertEquals(verdict.oid, 'd-e-file')
+  }
+})
+
+Deno.test('resolveSymlink: budget exhaustion returns cycle', async () => {
+  // Build a chain of 12 symlinks all pointing to the next (link0..link11 are
+  // symlinks, link12 is the terminal blob). Starting at target 'link1' means
+  // the resolver needs 11 follows to reach link12 — budget of 10 trips.
+  const objs: ObjSpec[] = []
+  for (let i = 0; i < 13; i++) {
+    const name = `link${i}`
+    if (i < 12) {
+      objs.push(blob(name, `link${i + 1}`, linkMode))
+    } else {
+      objs.push(blob(name, 'terminal'))
+    }
+  }
+  const source = fakeTreeSource(objs)
+  const verdict = await resolveSymlink('link0', 'link1', source, budget(10))
+  assertEquals(verdict, { kind: 'unresolved', reason: 'cycle' })
+})
+
+Deno.test('resolveSymlink: mutual cycle a <-> b returns cycle', async () => {
+  const source = fakeTreeSource([
+    blob('a', 'b', linkMode),
+    blob('b', 'a', linkMode),
+  ])
+  const verdict = await resolveSymlink('a', 'b', source, budget())
+  assertEquals(verdict, { kind: 'unresolved', reason: 'cycle' })
+})

--- a/src/files/gitResolver.test.ts
+++ b/src/files/gitResolver.test.ts
@@ -1,8 +1,9 @@
-import { assertEquals } from '@std/assert'
+import { assertEquals, assertExists } from '@std/assert'
 import { join } from '@std/path'
 import * as posix from '@std/path/posix'
 import type { FollowBudget, ResolveVerdict, TreeSource } from './gitResolver.ts'
-import { findSubmoduleAncestor, resolveSymlink } from './gitResolver.ts'
+import { findSubmoduleAncestor, graftTree, resolveSymlink } from './gitResolver.ts'
+import { FileIgnoreRules } from './ignore.ts'
 import { hasGit, isWindows, withRepo } from './utils.test.ts'
 
 type objType = 'tree' | 'blob' | 'commit'
@@ -293,4 +294,118 @@ Deno.test('resolveSymlink: mutual cycle a <-> b returns cycle', async () => {
   ])
   const verdict = await resolveSymlink('a', 'b', source, budget())
   assertEquals(verdict, { kind: 'unresolved', reason: 'cycle' })
+})
+
+function treeVerdict(
+  treePath: string,
+  originalDir: string,
+  source: TreeSource,
+): Extract<ResolveVerdict, { kind: 'tree' }> {
+  return { kind: 'tree', treePath, originalDir, source }
+}
+
+Deno.test('graftTree: grafts a flat directory', async () => {
+  const source = fakeTreeSource([
+    blob('target/a.txt'),
+    blob('target/b.txt'),
+    blob('view', 'target/', linkMode),
+  ])
+  const verdict = treeVerdict('target', '', source)
+
+  const result = await graftTree('/view', verdict, budget(), new Set())
+  const paths = result.files.map((f) => f.path).sort()
+  assertEquals(paths, ['/view/a.txt', '/view/b.txt'])
+  assertEquals(result.links, [])
+})
+
+Deno.test('graftTree: recurses into nested directories', async () => {
+  const source = fakeTreeSource([
+    blob('target/top.txt'),
+    blob('target/sub/deep.txt'),
+    blob('view', 'target/', linkMode),
+  ])
+  const verdict = treeVerdict('target', '', source)
+
+  const result = await graftTree('/view', verdict, budget(), new Set())
+  const paths = result.files.map((f) => f.path).sort()
+  assertEquals(paths, ['/view/sub/deep.txt', '/view/top.txt'])
+})
+
+Deno.test('graftTree: emits cycle at graftPath when visited set already contains it', async () => {
+  const source = fakeTreeSource([])
+  const verdict = treeVerdict('target', '', source)
+  const visited = new Set<string>(['/view'])
+
+  const result = await graftTree('/view', verdict, budget(), visited)
+  assertEquals(result.files, [])
+  assertEquals(result.links.length, 1)
+  assertEquals(result.links[0].path, '/view')
+  assertEquals(result.links[0].reason, 'cycle')
+})
+
+Deno.test('graftTree: respects prune at the grafted path', async () => {
+  const source = fakeTreeSource([
+    blob('target/keep.txt'),
+    blob('target/skip.txt'),
+  ])
+  const verdict = treeVerdict('target', '', source)
+  const prune = new FileIgnoreRules(['/view/skip.txt'])
+
+  const result = await graftTree('/view', verdict, budget(), new Set(), prune)
+  const paths = result.files.map((f) => f.path).sort()
+  assertEquals(paths, ['/view/keep.txt'])
+})
+
+Deno.test('graftTree: grafts nested file symlink with original-location semantics', async () => {
+  // /target/link.txt is a symlink to "../foo.txt"
+  // Under Unix physical-path rules, that resolves to /foo.txt, not /view/foo.txt.
+  const source = fakeTreeSource([
+    blob('foo.txt'),
+    blob('target/link.txt', '../foo.txt', linkMode),
+    blob('view', 'target/', linkMode),
+  ])
+  const verdict = treeVerdict('target', '', source)
+
+  const result = await graftTree('/view', verdict, budget(), new Set())
+  const paths = result.files.map((f) => f.path).sort()
+  assertEquals(paths, ['/view/link.txt'])
+  // The grafted file's opener points at foo.txt's oid — assert via the internal
+  // opener structure. GitFileOpener stores `oid` as a public property.
+  const grafted = result.files.find((f) => f.path === '/view/link.txt')
+  assertExists(grafted)
+  // deno-lint-ignore no-explicit-any
+  assertEquals((grafted.opener as any).oid, 'foo-txt')
+})
+
+Deno.test('graftTree: mutual dir symlinks a<->b produce no files and a cycle link', async () => {
+  const source = fakeTreeSource([
+    blob('a', 'b/', linkMode),
+    blob('b', 'a/', linkMode),
+  ])
+  const verdict = await resolveSymlink('a', 'b/', source, budget())
+  assertEquals(verdict, { kind: 'unresolved', reason: 'cycle' })
+})
+
+Deno.test('graftTree: dir symlink back into ancestor produces finite recursion', async () => {
+  const source = fakeTreeSource([
+    blob('a', 'd/', linkMode),
+    blob('d/sub', '../a/', linkMode),
+    blob('d/file.txt'),
+  ])
+  const b = budget(10)
+  const topVerdict = await resolveSymlink('a', 'd/', source, b)
+  assertEquals(topVerdict.kind, 'tree')
+  if (topVerdict.kind !== 'tree') return
+
+  const result = await graftTree('/a', topVerdict, b, new Set())
+  // We should see a finite number of /a/file.txt entries (one per recursion
+  // level reached before the budget ran out) plus at least one cycle link.
+  const fileTxtPaths = result.files
+    .map((f) => f.path)
+    .filter((p) => p.endsWith('/file.txt'))
+  assertEquals(fileTxtPaths.length > 0, true, 'expected at least one grafted file')
+  const cycleLinks = result.links.filter((l) => l.reason === 'cycle')
+  assertEquals(cycleLinks.length > 0, true, 'expected at least one cycle link')
+  // Sanity: recursion terminates.
+  assertEquals(result.files.length < 1000, true, 'recursion did not terminate')
 })

--- a/src/files/gitResolver.test.ts
+++ b/src/files/gitResolver.test.ts
@@ -201,6 +201,15 @@ Deno.test('resolveSymlink: relative escape above root is out-of-tree', async () 
   assertEquals(verdict, { kind: 'unresolved', reason: 'out-of-tree' })
 })
 
+Deno.test('resolveSymlink: blob as intermediate path is broken', async () => {
+  const source = fakeTreeSource([
+    blob('a/foo'),
+    blob('link', 'a/foo/subfile', linkMode),
+  ])
+  const verdict = await resolveSymlink('link', 'a/foo/subfile', source, budget())
+  assertEquals(verdict, { kind: 'unresolved', reason: 'broken' })
+})
+
 Deno.test('resolveSymlink: missing target is broken', async () => {
   const source = fakeTreeSource([
     blob('a/link', '../nowhere.txt', linkMode),
@@ -248,6 +257,20 @@ Deno.test('resolveSymlink: terminal chain resolving to an annex key', async () =
   if (verdict.kind === 'annex') {
     assertEquals(verdict.key, annexKey)
     assertEquals(verdict.size, 1234)
+  }
+})
+
+Deno.test('resolveSymlink: annex keys must not be directories', async () => {
+  const annexKey = 'MD5E-s1234--d41d8cd98f00b204e9800998ecf8427e.nii.gz'
+  const annexTarget = `../.git/annex/objects/xx/yy/${annexKey}/${annexKey}`
+  const source = fakeTreeSource([
+    blob('link', annexTarget, linkMode),
+    blob('alias', 'link/child', linkMode),
+  ])
+  const verdict = await resolveSymlink('alias', 'link/child', source, budget())
+  assertEquals(verdict.kind, 'unresolved')
+  if (verdict.kind === 'unresolved') {
+    assertEquals(verdict.reason, 'broken')
   }
 })
 

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -333,6 +333,25 @@ async function walkSubtree(
       }
       const target = source.symlinkMap.get(entryPath)
       if (target === undefined) continue
+      // Annex pointer symlinks are identified from the raw target string
+      // and do not need chain resolution. This mirrors the top-level walk
+      // in readGitTree, which short-circuits annex pointers before any
+      // resolver call.
+      const annexParsed = parseAnnexKey(target)
+      if (annexParsed !== null) {
+        result.files.push(
+          new BIDSFile(
+            outPath,
+            new AnnexedGitFileOpener(
+              annexParsed.key,
+              annexParsed.size,
+              source.gitOptions,
+              source.preferredRemote,
+            ),
+          ),
+        )
+        continue
+      }
       // Resolve nested symlinks against their ORIGINAL path (entryPath),
       // not their grafted path (outPath). Unix physical-path semantics.
       const subVerdict = await resolveSymlink(entryPath, target, source, budget, prune)

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -14,6 +14,8 @@
  * See docs/dev/discussion/2026-04-git_directory_symlink_grafting.md for
  * the full design.
  */
+import { default as git } from 'isomorphic-git'
+import type { ParsedTreeObject, ReadObjectResult } from 'isomorphic-git'
 import type { BIDSFile, SymlinkReason, UnresolvedLink } from '../types/filetree.ts'
 import type { GitOptions } from './git.ts'
 import type { FileIgnoreRules } from './ignore.ts'
@@ -50,7 +52,71 @@ export interface GraftResult {
   links: UnresolvedLink[]
 }
 
+// The effective type of `readObject` if filename is passed
+export type ParsedObject = Extract<ReadObjectResult, { format: 'parsed'; type: 'tree' | 'blob' }>
+
 export const MAX_SYMLINK_FOLLOWS = 10
+
+/**
+ * Read a git object by filepath relative to the TreeSource commit.
+ *
+ * Production path delegates to isomorphic-git's `readObject`. Tests may
+ * inject a `__fake` map on gitOptions.cache: when present, it short-circuits
+ * the real git call and returns a shaped object from the map.
+ */
+async function readObjectAt(
+  source: TreeSource,
+  filepath: string,
+): Promise<ParsedObject | null> {
+  // deno-lint-ignore no-explicit-any
+  const fakeMap = (source.gitOptions.cache as any)?.__fake as Map<string, ParsedObject>
+  if (fakeMap) {
+    return fakeMap.get(filepath) ?? null
+  }
+  try {
+    return await git.readObject({
+      oid: source.commitOid,
+      filepath,
+      ...source.gitOptions,
+    }) as ParsedObject
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Walk prefixes of a resolved path looking for a gitlink entry (submodule).
+ *
+ * Returns `{ mountPath, remainder }` on the first prefix whose parent tree
+ * contains an entry matching the next segment with type 'commit'. Returns
+ * null if the walk completes without seeing a gitlink, if a prefix lookup
+ * fails, or if an intermediate segment is not a tree.
+ *
+ * The remainder is the slash-joined remainder of the path after the mount
+ * point (possibly empty if the path itself is the mount).
+ */
+export async function findSubmoduleAncestor(
+  resolvedPath: string,
+  source: TreeSource,
+): Promise<{ mountPath: string; remainder: string } | null> {
+  const segments = resolvedPath.split('/').filter((s) => s !== '')
+  let prefix = ''
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i]
+    const parentObj = await readObjectAt(source, prefix)
+    if (!parentObj || parentObj.type !== 'tree') return null
+    const match = (parentObj as ParsedTreeObject).object.find((e) => e.path === segment)
+    if (!match) return null
+    if (match.type === 'commit') {
+      const mountPath = prefix === '' ? segment : `${prefix}/${segment}`
+      const remainder = segments.slice(i + 1).join('/')
+      return { mountPath, remainder }
+    }
+    if (match.type !== 'tree') return null
+    prefix = prefix === '' ? segment : `${prefix}/${segment}`
+  }
+  return null
+}
 
 // Segment-aware resolver. Filled in by Task 3.
 export function resolveSymlink(

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -133,18 +133,12 @@ export async function findSubmoduleAncestor(
  * The resolver walks one segment at a time. On each symlink follow
  * (intermediate or terminal), it decrements the shared `budget`; when the
  * budget hits zero it returns `{ kind: 'unresolved', reason: 'cycle' }`.
- *
- * Note on `prune`: accepted but currently unused in the resolver itself.
- * `prune` is applied by the graft walker at grafted paths. A future
- * optimization may short-circuit resolution for targets that land under a
- * pruned prefix.
  */
 export async function resolveSymlink(
   originalPath: string,
   target: string,
   source: TreeSource,
   budget: FollowBudget,
-  _prune?: FileIgnoreRules,
 ): Promise<ResolveVerdict> {
   // Reject absolute targets immediately; the git tree has no OS filesystem root.
   if (target.startsWith('/')) {
@@ -354,7 +348,7 @@ async function walkSubtree(
       }
       // Resolve nested symlinks against their ORIGINAL path (entryPath),
       // not their grafted path (outPath). Unix physical-path semantics.
-      const subVerdict = await resolveSymlink(entryPath, target, source, budget, prune)
+      const subVerdict = await resolveSymlink(entryPath, target, source, budget)
       switch (subVerdict.kind) {
         case 'file-blob':
           result.files.push(

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -1,0 +1,75 @@
+/**
+ * Symlink resolver and directory graft walker for the git-tree backend.
+ *
+ * This module walks symlink targets segment-by-segment using Unix
+ * physical-path semantics and produces verdicts that src/files/git.ts
+ * dispatches on. Directory-valued verdicts feed the graft walker, which
+ * recursively mounts target subtrees at symlink paths.
+ *
+ * Cycle detection uses two complementary guards:
+ *   - a shared per-resolution follow budget (chain cycles)
+ *   - a per-top-level-graft visited set of directory-symlink paths
+ *     currently on the recursion stack (structural graft cycles)
+ *
+ * See docs/dev/discussion/2026-04-git_directory_symlink_grafting.md for
+ * the full design.
+ */
+import type { BIDSFile, SymlinkReason, UnresolvedLink } from '../types/filetree.ts'
+import type { GitOptions } from './git.ts'
+import type { FileIgnoreRules } from './ignore.ts'
+
+export interface TreeSource {
+  readonly commitOid: string
+  readonly gitOptions: GitOptions
+  readonly symlinkMap: ReadonlyMap<string, string>
+  readonly preferredRemote?: string
+  /** Forward-compatibility for submodule descent. Unused today. */
+  readonly parent?: TreeSource
+  /** Forward-compatibility for submodule descent. Unused today. */
+  readonly children?: ReadonlyMap<string, TreeSource>
+}
+
+export interface FollowBudget {
+  remaining: number
+}
+
+export type ResolveVerdict =
+  | { kind: 'file-blob'; oid: string; size: number; source: TreeSource }
+  | { kind: 'annex'; key: string; size: number; source: TreeSource }
+  | { kind: 'tree'; treePath: string; originalDir: string; source: TreeSource }
+  | {
+    kind: 'submodule-boundary'
+    mountPath: string
+    remainder: string
+    source: TreeSource
+  }
+  | { kind: 'unresolved'; reason: SymlinkReason }
+
+export interface GraftResult {
+  files: BIDSFile[]
+  links: UnresolvedLink[]
+}
+
+export const MAX_SYMLINK_FOLLOWS = 10
+
+// Segment-aware resolver. Filled in by Task 3.
+export function resolveSymlink(
+  _originalPath: string,
+  _target: string,
+  _source: TreeSource,
+  _budget: FollowBudget,
+  _prune?: FileIgnoreRules,
+): Promise<ResolveVerdict> {
+  return Promise.reject(new Error('resolveSymlink: not implemented yet'))
+}
+
+// Directory graft walker. Filled in by Task 5.
+export function graftTree(
+  _graftPath: string,
+  _verdict: Extract<ResolveVerdict, { kind: 'tree' }>,
+  _budget: FollowBudget,
+  _visited: Set<string>,
+  _prune?: FileIgnoreRules,
+): Promise<GraftResult> {
+  return Promise.reject(new Error('graftTree: not implemented yet'))
+}

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -14,11 +14,13 @@
  * See docs/dev/discussion/2026-04-git_directory_symlink_grafting.md for
  * the full design.
  */
+import * as posix from '@std/path/posix'
 import { default as git } from 'isomorphic-git'
 import type { ParsedTreeObject, ReadObjectResult } from 'isomorphic-git'
 import type { BIDSFile, SymlinkReason, UnresolvedLink } from '../types/filetree.ts'
 import type { GitOptions } from './git.ts'
 import type { FileIgnoreRules } from './ignore.ts'
+import { parseAnnexKey } from './repo.ts'
 
 export interface TreeSource {
   readonly commitOid: string
@@ -118,15 +120,112 @@ export async function findSubmoduleAncestor(
   return null
 }
 
-// Segment-aware resolver. Filled in by Task 3.
-export function resolveSymlink(
-  _originalPath: string,
-  _target: string,
-  _source: TreeSource,
-  _budget: FollowBudget,
+/**
+ * Resolve a symlink target against a TreeSource using Unix physical-path
+ * semantics: relative path components are anchored at the directory where
+ * the current symlink blob physically lives in the git tree.
+ *
+ * The resolver walks one segment at a time. On each symlink follow
+ * (intermediate or terminal), it decrements the shared `budget`; when the
+ * budget hits zero it returns `{ kind: 'unresolved', reason: 'cycle' }`.
+ *
+ * Note on `prune`: accepted but currently unused in the resolver itself.
+ * `prune` is applied by the graft walker at grafted paths. A future
+ * optimization may short-circuit resolution for targets that land under a
+ * pruned prefix.
+ */
+export async function resolveSymlink(
+  originalPath: string,
+  target: string,
+  source: TreeSource,
+  budget: FollowBudget,
   _prune?: FileIgnoreRules,
 ): Promise<ResolveVerdict> {
-  return Promise.reject(new Error('resolveSymlink: not implemented yet'))
+  // Reject absolute targets immediately; the git tree has no OS filesystem root.
+  if (target.startsWith('/')) {
+    return { kind: 'unresolved', reason: 'out-of-tree' }
+  }
+
+  // `accumulated` is the resolved path walked so far (relative to source root).
+  // Starts at the dirname of the original symlink: Unix physical-path rule.
+  let accumulated = posix.dirname(originalPath)
+  if (accumulated === '.') accumulated = ''
+
+  // `segments` is the queue of remaining components from the target string,
+  // plus any components pushed onto the front when we follow a chain.
+  let segments = target.split('/')
+
+  while (segments.length > 0) {
+    const seg = segments.shift() as string
+    if (seg === '' || seg === '.') continue
+    if (seg === '..') {
+      if (accumulated === '') {
+        return { kind: 'unresolved', reason: 'out-of-tree' }
+      }
+      accumulated = posix.dirname(accumulated)
+      if (accumulated === '.') accumulated = ''
+      continue
+    }
+    const candidate = accumulated === '' ? seg : `${accumulated}/${seg}`
+
+    // Intermediate or terminal symlink? Consult symlinkMap first.
+    const nextTarget = source.symlinkMap.get(candidate)
+    if (nextTarget !== undefined) {
+      if (budget.remaining <= 0) {
+        return { kind: 'unresolved', reason: 'cycle' }
+      }
+      budget.remaining--
+
+      // Annex keys may only terminate a resolution — annex blobs are opaque
+      // content, not directories. If the chain is about to continue into an
+      // annex key, treat that as a not-a-directory broken link.
+      const annex = parseAnnexKey(nextTarget)
+      if (annex !== null) {
+        if (segments.length === 0) {
+          return { kind: 'annex', source, ...annex }
+        }
+        return { kind: 'unresolved', reason: 'broken' }
+      }
+
+      // Follow: reset accumulated to the dirname of the followed symlink,
+      // prepend the new target's segments to whatever remained.
+      accumulated = posix.dirname(candidate)
+      if (accumulated === '.') accumulated = ''
+      segments = [...nextTarget.split('/'), ...segments]
+      continue
+    }
+
+    // Not a symlink; consult the tree object model.
+    const obj = await readObjectAt(source, candidate)
+    if (obj === null) {
+      const boundary = await findSubmoduleAncestor(posix.join(candidate, ...segments), source)
+      if (boundary !== null) {
+        return { kind: 'submodule-boundary', source, ...boundary }
+      }
+      return { kind: 'unresolved', reason: 'broken' }
+    }
+    if (obj.type === 'blob') {
+      if (segments.length > 0) {
+        // Blob with more segments to resolve — "not a directory".
+        return { kind: 'unresolved', reason: 'broken' }
+      }
+      return { kind: 'file-blob', oid: obj.oid, size: obj.object.length, source }
+    }
+    // deno-coverage-ignore-start
+    if (obj.type !== 'tree') {
+      throw new Error(`Unhandled object type: ${(obj as { type: string }).type}`)
+      // deno-coverage-ignore-stop
+    }
+    accumulated = candidate
+  }
+
+  // We've exited the loop without finding a blob, link or missing target
+  return {
+    kind: 'tree',
+    treePath: accumulated,
+    originalDir: posix.dirname(originalPath) === '.' ? '' : posix.dirname(originalPath),
+    source,
+  }
 }
 
 // Directory graft walker. Filled in by Task 5.

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -16,8 +16,10 @@
  */
 import * as posix from '@std/path/posix'
 import { default as git } from 'isomorphic-git'
-import type { FsClient, ParsedTreeObject, ReadObjectResult } from 'isomorphic-git'
-import type { BIDSFile, SymlinkReason, UnresolvedLink } from '../types/filetree.ts'
+import type { FsClient, ParsedTreeObject, ReadObjectResult, TreeEntry } from 'isomorphic-git'
+import { BIDSFile } from '../types/filetree.ts'
+import type { SymlinkReason, UnresolvedLink } from '../types/filetree.ts'
+import { AnnexedGitFileOpener, GitFileOpener } from './git.ts'
 import type { FileIgnoreRules } from './ignore.ts'
 import { parseAnnexKey } from './repo.ts'
 
@@ -110,9 +112,7 @@ export async function findSubmoduleAncestor(
   let prefix = ''
   for (let i = 0; i < segments.length; i++) {
     const segment = segments[i]
-    const parentObj = await readObjectAt(source, prefix)
-    if (!parentObj || parentObj.type !== 'tree') return null
-    const match = (parentObj as ParsedTreeObject).object.find((e) => e.path === segment)
+    const match = (await listTreeEntries(source, prefix)).find((e) => e.path === segment)
     if (!match) return null
     if (match.type === 'commit') {
       const mountPath = prefix === '' ? segment : `${prefix}/${segment}`
@@ -233,13 +233,149 @@ export async function resolveSymlink(
   }
 }
 
-// Directory graft walker. Filled in by Task 5.
-export function graftTree(
-  _graftPath: string,
-  _verdict: Extract<ResolveVerdict, { kind: 'tree' }>,
-  _budget: FollowBudget,
-  _visited: Set<string>,
-  _prune?: FileIgnoreRules,
+async function listTreeEntries(
+  source: TreeSource,
+  treePath: string,
+): Promise<TreeEntry[]> {
+  const obj = await readObjectAt(source, treePath)
+  if (!obj || obj.type !== 'tree') return []
+  return (obj as ParsedTreeObject).object
+}
+
+/**
+ * Recursively walk a target subtree inside `source` and produce
+ * BIDSFile entries at `graftPath/...` plus UnresolvedLink entries for
+ * anything that fails to resolve. See
+ * docs/dev/discussion/2026-04-git_directory_symlink_grafting.md §
+ * "Algorithm: directory graft walker" for the full behavior.
+ */
+export async function graftTree(
+  graftPath: string,
+  verdict: Extract<ResolveVerdict, { kind: 'tree' }>,
+  budget: FollowBudget,
+  visited: Set<string>,
+  prune?: FileIgnoreRules,
 ): Promise<GraftResult> {
-  return Promise.reject(new Error('graftTree: not implemented yet'))
+  if (visited.has(graftPath)) {
+    return {
+      files: [],
+      links: [{ path: graftPath, target: verdict.treePath, reason: 'cycle' }],
+    }
+  }
+  visited.add(graftPath)
+  try {
+    return await walkSubtree(
+      graftPath,
+      verdict.treePath,
+      verdict.source,
+      budget,
+      visited,
+      prune,
+    )
+  } finally {
+    visited.delete(graftPath)
+  }
+}
+
+async function walkSubtree(
+  graftPath: string,
+  treePath: string,
+  source: TreeSource,
+  budget: FollowBudget,
+  visited: Set<string>,
+  prune?: FileIgnoreRules,
+): Promise<GraftResult> {
+  const result: GraftResult = { files: [], links: [] }
+  const entries = await listTreeEntries(source, treePath)
+
+  for (const entry of entries) {
+    const entryPath = treePath === '' ? entry.path : `${treePath}/${entry.path}`
+    const outPath = graftPath === '/' || graftPath === ''
+      ? `/${entry.path}`
+      : `${graftPath}/${entry.path}`
+
+    if (prune && prune.test(outPath)) continue
+
+    if (entry.type === 'tree') {
+      // Recurse with the child outPath as the new graftPath and the
+      // child entryPath as the new treePath. Forwarding the parent
+      // graftPath would mis-anchor grafted file paths.
+      const nested = await walkSubtree(
+        outPath,
+        entryPath,
+        source,
+        budget,
+        visited,
+        prune,
+      )
+      result.files.push(...nested.files)
+      result.links.push(...nested.links)
+      continue
+    }
+
+    if (entry.type === 'commit') {
+      // Gitlink nested inside a grafted subtree — unsupported today.
+      result.links.push({ path: outPath, target: '', reason: 'submodule' })
+      continue
+    }
+
+    if (entry.type === 'blob') {
+      if (entry.mode !== '120000') {
+        const obj = await readObjectAt(source, entryPath)
+        if (!obj || obj.type !== 'blob') continue
+        result.files.push(
+          new BIDSFile(
+            outPath,
+            new GitFileOpener(obj.oid, obj.object.length, source.gitOptions),
+          ),
+        )
+        continue
+      }
+      const target = source.symlinkMap.get(entryPath)
+      if (target === undefined) continue
+      // Resolve nested symlinks against their ORIGINAL path (entryPath),
+      // not their grafted path (outPath). Unix physical-path semantics.
+      const subVerdict = await resolveSymlink(entryPath, target, source, budget, prune)
+      switch (subVerdict.kind) {
+        case 'file-blob':
+          result.files.push(
+            new BIDSFile(
+              outPath,
+              new GitFileOpener(
+                subVerdict.oid,
+                subVerdict.size,
+                subVerdict.source.gitOptions,
+              ),
+            ),
+          )
+          break
+        case 'annex':
+          result.files.push(
+            new BIDSFile(
+              outPath,
+              new AnnexedGitFileOpener(
+                subVerdict.key,
+                subVerdict.size,
+                subVerdict.source.gitOptions,
+                subVerdict.source.preferredRemote,
+              ),
+            ),
+          )
+          break
+        case 'tree': {
+          const nested = await graftTree(outPath, subVerdict, budget, visited, prune)
+          result.files.push(...nested.files)
+          result.links.push(...nested.links)
+          break
+        }
+        case 'submodule-boundary':
+          result.links.push({ path: outPath, target, reason: 'submodule' })
+          break
+        case 'unresolved':
+          result.links.push({ path: outPath, target, reason: subVerdict.reason })
+          break
+      }
+    }
+  }
+  return result
 }

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -16,11 +16,16 @@
  */
 import * as posix from '@std/path/posix'
 import { default as git } from 'isomorphic-git'
-import type { ParsedTreeObject, ReadObjectResult } from 'isomorphic-git'
+import type { FsClient, ParsedTreeObject, ReadObjectResult } from 'isomorphic-git'
 import type { BIDSFile, SymlinkReason, UnresolvedLink } from '../types/filetree.ts'
-import type { GitOptions } from './git.ts'
 import type { FileIgnoreRules } from './ignore.ts'
 import { parseAnnexKey } from './repo.ts'
+
+export interface GitOptions {
+  fs: FsClient
+  gitdir: string
+  cache: object
+}
 
 export interface TreeSource {
   readonly commitOid: string

--- a/src/files/symlinkCrossBackend.test.ts
+++ b/src/files/symlinkCrossBackend.test.ts
@@ -273,6 +273,102 @@ Deno.test(
   },
 )
 
+Deno.test(
+  {
+    name: 'cross-backend: .bidsignore applies at grafted paths',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'target'))
+        await Deno.writeTextFile(join(repo, 'target', 'keep.txt'), 'kept')
+        await Deno.writeTextFile(join(repo, 'target', 'skip.txt'), 'skipped')
+        await run(['ln', '-s', 'target', join(repo, 'view')])
+      },
+      async (repo) => {
+        // Prune rule: ignore /view/skip.txt at the grafted path, plus .git.
+        // Pass the prune via the prune argument — it should test grafted paths
+        // in both backends and produce identical results.
+        const prune = new FileIgnoreRules(['/view/skip.txt', '.git', '.git/**'])
+        const gitTree = await readGitTree(repo, 'HEAD', prune)
+        const fsTree = await readFileTree(repo, prune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        const gitFiles = collectFiles(gitTree)
+        assertEquals(gitFiles.has('/view/keep.txt'), true)
+        assertEquals(gitFiles.has('/view/skip.txt'), false)
+        // Original source files are still present.
+        assertEquals(gitFiles.has('/target/keep.txt'), true)
+        assertEquals(gitFiles.has('/target/skip.txt'), true)
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'cross-backend: symlink with intermediate directory-symlink segment resolves',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        // Layout:
+        //   d/e/file.txt      — actual content
+        //   a/c               — symlink to ../d/e/
+        //   a/b/link          — symlink to ../c/file.txt
+        //                         resolves (via intermediate a/c) to d/e/file.txt
+        await Deno.mkdir(join(repo, 'd', 'e'), { recursive: true })
+        await Deno.writeTextFile(join(repo, 'd', 'e', 'file.txt'), 'deep-content')
+        await Deno.mkdir(join(repo, 'a', 'b'), { recursive: true })
+        await run(['ln', '-s', '../d/e', join(repo, 'a', 'c')])
+        await run(['ln', '-s', '../c/file.txt', join(repo, 'a', 'b', 'link')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        const link = gitTree.get('a/b/link') as BIDSFile
+        assertEquals(await link.text(), 'deep-content')
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'cross-backend: annex pointer symlink inside a grafted subtree reports size',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    const annexKey = 'MD5E-s4242--00112233445566778899aabbccddeeff.nii.gz'
+    const annexTarget = `../.git/annex/objects/xx/yy/${annexKey}/${annexKey}`
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'target'))
+        await run(['ln', '-s', annexTarget, join(repo, 'target', 'scan.nii.gz')])
+        await run(['ln', '-s', 'target', join(repo, 'view')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        const grafted = gitTree.get('view/scan.nii.gz') as BIDSFile
+        assertEquals(grafted.size, 4242)
+      },
+    )
+  },
+)
+
 export {
   assertTreeEquivalent,
   collectDirPaths,

--- a/src/files/symlinkCrossBackend.test.ts
+++ b/src/files/symlinkCrossBackend.test.ts
@@ -369,6 +369,51 @@ Deno.test(
   },
 )
 
+// ---------------------------------------------------------------------------
+// Documented inherent asymmetry: out-of-tree symlinks are valid in a work
+// tree (the OS follows them) but unresolvable in a git tree (no external
+// filesystem to consult). This test does NOT use assertTreeEquivalent; it
+// exists to pin down the one place the backends legitimately diverge.
+// ---------------------------------------------------------------------------
+
+Deno.test(
+  {
+    name:
+      'cross-backend asymmetry: out-of-tree symlink is valid in fs tree, out-of-tree in git tree',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    const externalFile = await Deno.makeTempFile({ prefix: 'bids-symlink-ext-' })
+    await Deno.writeTextFile(externalFile, 'external-content')
+    try {
+      await withRepo(
+        async (repo) => {
+          await Deno.writeTextFile(join(repo, '.keep'), '')
+          await run(['ln', '-s', externalFile, join(repo, 'outside')])
+        },
+        async (repo) => {
+          const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+          const fsTree = await readFileTree(repo, gitPrune)
+
+          // Git tree: outside is absent from files and present as an out-of-tree link.
+          assertEquals(gitTree.get('outside'), undefined)
+          const outOfTreeLinks = collectLinks(gitTree).filter((l) => l.reason === 'out-of-tree')
+          assertEquals(outOfTreeLinks.length, 1)
+          assertEquals(outOfTreeLinks[0].path, '/outside')
+
+          // Fs tree: outside is a regular file whose content is the external file.
+          const fsOutside = fsTree.get('outside') as BIDSFile
+          assertEquals(await fsOutside.text(), 'external-content')
+        },
+      )
+    } finally {
+      await Deno.remove(externalFile)
+    }
+  },
+)
+
 export {
   assertTreeEquivalent,
   collectDirPaths,

--- a/src/files/symlinkCrossBackend.test.ts
+++ b/src/files/symlinkCrossBackend.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Cross-backend equivalence tests for symlink handling.
+ *
+ * Each test builds a real git repository in a temporary directory,
+ * commits its contents, then runs BOTH readGitTree() and readFileTree()
+ * over the same worktree. assertTreeEquivalent compares the two trees,
+ * asserting the same set of file paths, the same per-file content, the
+ * same unresolved links (modulo reasons the work tree cannot detect),
+ * and the same directory structure.
+ *
+ * These tests exercise the full path from the segment-aware resolver
+ * through graftTree and into the FileTree assembly in git.ts and
+ * deno.ts. They are the primary oracle for the grafting work.
+ */
+import { join } from '@std/path'
+import { assertEquals } from '@std/assert'
+import { readGitTree } from './git.ts'
+import { readFileTree } from './deno.ts'
+import { FileIgnoreRules } from './ignore.ts'
+import type { BIDSFile, FileTree, SymlinkReason } from '../types/filetree.ts'
+import { hasGit, isWindows, run, withRepo } from './utils.test.ts'
+
+/**
+ * Shared prune rule for cross-backend tests: excludes the `.git/`
+ * metadata directory from the work-tree walk. readGitTree only sees
+ * committed blobs and never surfaces `.git/` contents, so readFileTree
+ * must be given this prune to produce a comparable tree.
+ */
+const gitPrune = new FileIgnoreRules(['.git', '.git/**'], false)
+
+function collectFiles(
+  tree: FileTree,
+  out: Map<string, BIDSFile> = new Map(),
+): Map<string, BIDSFile> {
+  for (const f of tree.files) out.set(f.path, f)
+  for (const d of tree.directories) collectFiles(d, out)
+  return out
+}
+
+function collectDirPaths(tree: FileTree, out: Set<string> = new Set()): Set<string> {
+  out.add(tree.path)
+  for (const d of tree.directories) collectDirPaths(d, out)
+  return out
+}
+
+function collectLinks(
+  tree: FileTree,
+  out: Array<{ path: string; reason: SymlinkReason }> = [],
+): Array<{ path: string; reason: SymlinkReason }> {
+  for (const l of tree.links) out.push({ path: l.path, reason: l.reason })
+  for (const d of tree.directories) collectLinks(d, out)
+  return out
+}
+
+interface EquivalenceOptions {
+  /** Reasons the work tree legitimately cannot produce; exclude from compare. */
+  linkReasonsIgnoredOnFs?: SymlinkReason[]
+}
+
+async function assertTreeEquivalent(
+  gitTree: FileTree,
+  fsTree: FileTree,
+  options: EquivalenceOptions = {},
+): Promise<void> {
+  const gitFiles = collectFiles(gitTree)
+  const fsFiles = collectFiles(fsTree)
+
+  const gitPaths = [...gitFiles.keys()].sort()
+  const fsPaths = [...fsFiles.keys()].sort()
+  assertEquals(gitPaths, fsPaths, 'file paths differ between git and fs trees')
+
+  for (const path of gitPaths) {
+    const gitContent = await (gitFiles.get(path) as BIDSFile).text()
+    const fsContent = await (fsFiles.get(path) as BIDSFile).text()
+    assertEquals(gitContent, fsContent, `content differs for ${path}`)
+  }
+
+  const gitDirs = [...collectDirPaths(gitTree)].sort()
+  const fsDirs = [...collectDirPaths(fsTree)].sort()
+  assertEquals(gitDirs, fsDirs, 'directory structure differs between git and fs trees')
+
+  const ignored = new Set(options.linkReasonsIgnoredOnFs ?? [])
+  const gitLinks = collectLinks(gitTree)
+    .filter((l) => !ignored.has(l.reason))
+    .map((l) => `${l.path}:${l.reason}`)
+    .sort()
+  const fsLinks = collectLinks(fsTree)
+    .filter((l) => !ignored.has(l.reason))
+    .map((l) => `${l.path}:${l.reason}`)
+    .sort()
+  assertEquals(gitLinks, fsLinks, 'unresolved links differ between git and fs trees')
+}
+
+Deno.test(
+  {
+    name: 'cross-backend: basic directory symlink graft',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'target'))
+        await Deno.writeTextFile(join(repo, 'target', 'a.txt'), 'alpha')
+        await Deno.writeTextFile(join(repo, 'target', 'b.txt'), 'bravo')
+        await run(['ln', '-s', 'target', join(repo, 'view')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        // Sanity: both paths exist and resolve to the same content.
+        const viewA = gitTree.get('view/a.txt') as BIDSFile
+        const targetA = gitTree.get('target/a.txt') as BIDSFile
+        assertEquals(await viewA.text(), 'alpha')
+        assertEquals(await targetA.text(), 'alpha')
+      },
+    )
+  },
+)
+
+export {
+  assertTreeEquivalent,
+  collectDirPaths,
+  collectFiles,
+  collectLinks,
+  gitPrune,
+  hasGit,
+  isWindows,
+  run,
+  withRepo,
+}

--- a/src/files/symlinkCrossBackend.test.ts
+++ b/src/files/symlinkCrossBackend.test.ts
@@ -121,6 +121,95 @@ Deno.test(
   },
 )
 
+Deno.test(
+  {
+    name: 'cross-backend: grafted subtree contains nested file symlink with ..',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        // foo.txt lives at the root
+        await Deno.writeTextFile(join(repo, 'foo.txt'), 'the-content')
+        // target/link.txt is a symlink to "../foo.txt"
+        await Deno.mkdir(join(repo, 'target'))
+        await run(['ln', '-s', '../foo.txt', join(repo, 'target', 'link.txt')])
+        // view -> target/
+        await run(['ln', '-s', 'target', join(repo, 'view')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        const viewLink = gitTree.get('view/link.txt') as BIDSFile
+        assertEquals(await viewLink.text(), 'the-content')
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'cross-backend: grafted subtree contains nested directory symlink',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'sibling'))
+        await Deno.writeTextFile(join(repo, 'sibling', 'payload.txt'), 'sibling-payload')
+        await Deno.mkdir(join(repo, 'target'))
+        // target/inner -> ../sibling/ (nested directory symlink inside the graft source)
+        await run(['ln', '-s', '../sibling', join(repo, 'target', 'inner')])
+        // view -> target/
+        await run(['ln', '-s', 'target', join(repo, 'view')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        const viewInner = gitTree.get('view/inner/payload.txt') as BIDSFile
+        assertEquals(await viewInner.text(), 'sibling-payload')
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'cross-backend: nested broken symlink reports at both original and grafted paths',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'target'))
+        await Deno.writeTextFile(join(repo, 'target', 'ok.txt'), 'fine')
+        // target/orphan -> nonexistent (relative target inside target/)
+        await run(['ln', '-s', 'missing.txt', join(repo, 'target', 'orphan')])
+        await run(['ln', '-s', 'target', join(repo, 'view')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        const allLinks = collectLinks(gitTree).filter((l) => l.reason === 'broken')
+        const paths = allLinks.map((l) => l.path).sort()
+        assertEquals(paths, ['/target/orphan', '/view/orphan'])
+      },
+    )
+  },
+)
+
 export {
   assertTreeEquivalent,
   collectDirPaths,

--- a/src/files/symlinkCrossBackend.test.ts
+++ b/src/files/symlinkCrossBackend.test.ts
@@ -210,6 +210,69 @@ Deno.test(
   },
 )
 
+Deno.test(
+  {
+    name: 'cross-backend: mutual directory symlinks produce cycles at both paths',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.writeTextFile(join(repo, '.keep'), '')
+        await run(['ln', '-s', 'b', join(repo, 'a')])
+        await run(['ln', '-s', 'a', join(repo, 'b')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+        await assertTreeEquivalent(gitTree, fsTree)
+
+        const cycleLinks = collectLinks(gitTree).filter((l) => l.reason === 'cycle')
+        const paths = cycleLinks.map((l) => l.path).sort()
+        assertEquals(paths, ['/a', '/b'])
+      },
+    )
+  },
+)
+
+Deno.test(
+  {
+    name: 'cross-backend: dir symlink back into ancestor terminates with a cycle link',
+    ignore: !hasGit || isWindows,
+    sanitizeResources: false,
+    sanitizeOps: false,
+  },
+  async () => {
+    await withRepo(
+      async (repo) => {
+        await Deno.mkdir(join(repo, 'd'))
+        await Deno.writeTextFile(join(repo, 'd', 'file.txt'), 'payload')
+        // d/sub -> ../a/ (symlink)
+        await run(['ln', '-s', '../a', join(repo, 'd', 'sub')])
+        // a -> d/ (directory symlink at root)
+        await run(['ln', '-s', 'd', join(repo, 'a')])
+      },
+      async (repo) => {
+        const gitTree = await readGitTree(repo, 'HEAD', gitPrune)
+        const fsTree = await readFileTree(repo, gitPrune)
+
+        const gitFiles = collectFiles(gitTree)
+        const fsFiles = collectFiles(fsTree)
+
+        // Finite: neither backend should produce thousands of entries.
+        assertEquals(gitFiles.size < 500, true, 'git tree did not terminate')
+        assertEquals(fsFiles.size < 500, true, 'fs tree did not terminate')
+
+        // The real /d/file.txt exists in both.
+        assertEquals(gitFiles.has('/d/file.txt'), true)
+        assertEquals(fsFiles.has('/d/file.txt'), true)
+      },
+    )
+  },
+)
+
 export {
   assertTreeEquivalent,
   collectDirPaths,

--- a/src/files/utils.test.ts
+++ b/src/files/utils.test.ts
@@ -1,0 +1,65 @@
+async function commandExists(cmd: string): Promise<boolean> {
+  try {
+    const proc = new Deno.Command(cmd, { args: ['--help'], stdout: 'null', stderr: 'null' })
+    const { success } = await proc.output()
+    return success
+  } catch {
+    return false
+  }
+}
+
+export const hasGit = await commandExists('git')
+export const isWindows = Deno.build.os === 'windows'
+export const hasGitAnnex = await commandExists('git-annex')
+
+export async function run(cmd: string[]): Promise<void> {
+  const proc = new Deno.Command(cmd[0], {
+    args: cmd.slice(1),
+    stdout: 'piped',
+    stderr: 'piped',
+  })
+  const status = await proc.output()
+  if (!status.success) {
+    const stdout = new TextDecoder().decode(status.stdout).trim()
+    const stderr = new TextDecoder().decode(status.stderr).trim()
+    console.error(`Command failed: ${cmd.join(' ')}\n\tstdout: ${stdout}\n\tstderr: ${stderr}`)
+    throw new Error(`Command failed: ${cmd.join(' ')}`)
+  }
+}
+
+export async function capture(cmd: string[]): Promise<string> {
+  const proc = new Deno.Command(cmd[0], {
+    args: cmd.slice(1),
+    stdout: 'piped',
+    stderr: 'inherit',
+  })
+  const output = await proc.output()
+  if (!output.success) {
+    throw new Error(`Command failed: ${cmd.join(' ')}`)
+  }
+  return new TextDecoder().decode(output.stdout).trim()
+}
+
+/**
+ * Create a temporary git repo, run a setup callback to populate it,
+ * commit everything, then run a test callback with the repo path.
+ * Cleans up the temp directory in `finally`.
+ */
+export async function withRepo(
+  setup: (repoPath: string) => Promise<void>,
+  test: (repoPath: string) => Promise<void>,
+): Promise<void> {
+  const tmpDir = await Deno.makeTempDir()
+  try {
+    await run(['git', 'init', tmpDir])
+    await run(['git', '-C', tmpDir, 'config', 'user.email', 'test@test.com'])
+    await run(['git', '-C', tmpDir, 'config', 'user.name', 'Test'])
+    await setup(tmpDir)
+    await run(['git', '-C', tmpDir, 'add', '-A'])
+    await run(['git', '-C', tmpDir, 'commit', '-m', 'init'])
+    await test(tmpDir)
+  } finally {
+    await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()
+    await Deno.remove(tmpDir, { recursive: true })
+  }
+}

--- a/src/files/utils.test.ts
+++ b/src/files/utils.test.ts
@@ -56,7 +56,7 @@ export async function withRepo(
     await run(['git', '-C', tmpDir, 'config', 'user.name', 'Test'])
     await setup(tmpDir)
     await run(['git', '-C', tmpDir, 'add', '-A'])
-    await run(['git', '-C', tmpDir, 'commit', '-m', 'init'])
+    await run(['git', '-C', tmpDir, 'commit', '--no-gpg-sign', '-m', 'init'])
     await test(tmpDir)
   } finally {
     await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()

--- a/src/issues/list.ts
+++ b/src/issues/list.ts
@@ -228,10 +228,6 @@ export const bidsIssues: IssueDefinitionRecord = {
     severity: 'warning',
     reason: 'Symbolic link target lies within an uninitialized git submodule.',
   },
-  SYMLINK_DIRECTORY_UNSUPPORTED: {
-    severity: 'warning',
-    reason: 'Symbolic link to a directory is not yet supported when reading from a git tree.',
-  },
 }
 
 export const nonSchemaIssues = { ...bidsIssues }

--- a/src/schema/walk.test.ts
+++ b/src/schema/walk.test.ts
@@ -94,7 +94,6 @@ Deno.test('walkFileTree emits one issue per link with the correct code', async (
     { path: '/b', target: 't2', reason: 'cycle' },
     { path: '/c', target: 't3', reason: 'out-of-tree' },
     { path: '/d', target: 't4', reason: 'submodule' },
-    { path: '/e', target: 't5', reason: 'directory-unsupported' },
   ]
   for (const link of cases) tree.links.push(link)
   const ds = datasetFor(tree)
@@ -105,5 +104,4 @@ Deno.test('walkFileTree emits one issue per link with the correct code', async (
   assertEquals(ds.issues.get({ code: 'SYMLINK_CYCLE' }).length, 1)
   assertEquals(ds.issues.get({ code: 'SYMLINK_OUT_OF_TREE' }).length, 1)
   assertEquals(ds.issues.get({ code: 'SYMLINK_IN_SUBMODULE' }).length, 1)
-  assertEquals(ds.issues.get({ code: 'SYMLINK_DIRECTORY_UNSUPPORTED' }).length, 1)
 })

--- a/src/schema/walk.ts
+++ b/src/schema/walk.ts
@@ -12,7 +12,6 @@ const REASON_TO_CODE: Record<SymlinkReason, keyof typeof bidsIssues> = {
   'cycle': 'SYMLINK_CYCLE',
   'out-of-tree': 'SYMLINK_OUT_OF_TREE',
   'submodule': 'SYMLINK_IN_SUBMODULE',
-  'directory-unsupported': 'SYMLINK_DIRECTORY_UNSUPPORTED',
 }
 
 function* quickWalk(dir: FileTree): Generator<BIDSFile> {

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -13,7 +13,6 @@ export type SymlinkReason =
   | 'cycle'
   | 'submodule'
   | 'out-of-tree'
-  | 'directory-unsupported'
 
 export interface UnresolvedLink {
   path: string


### PR DESCRIPTION
In #380, we treated symlinks to directories as broken, in order to limit the scope. This PR demonstrates how big that scope change turned out to be.

There were two goals here:

1) Have in-tree directory symlinks behave identically in a git tree as in a filesystem crawl of a checked out repository.
2) Work in a way that will facilitate adding submodule support later.

The central data structures are:

```ts
export interface TreeSource {
  readonly commitOid: string
  readonly gitOptions: GitOptions
  readonly symlinkMap: ReadonlyMap<string, string>
  readonly preferredRemote?: string
}

export type ResolveVerdict =
  | { kind: 'file-blob'; oid: string; size: number; source: TreeSource }
  | { kind: 'annex'; key: string; size: number; source: TreeSource }
  | { kind: 'tree'; treePath: string; originalDir: string; source: TreeSource }
  | {
    kind: 'submodule-boundary'
    mountPath: string
    remainder: string
    source: TreeSource
  }
  | { kind: 'unresolved'; reason: SymlinkReason }
```

A `TreeSource` is passed around to allow git operations to be run while resolving symlinks and walking directories, which are the basic actions needed to implement directory links, and this will be able to be swapped out as we eventually cross submodule boundaries. The `ResolveVerdict` enumerates the kind of things that can be at the other end of a symlink. The thing that makes all of this complicated is that you can have cases like:

```
a/b/link -> ../c/e/file
a/c -> ../d
d/e/file
```

The git tree needs to expand to three resolved blobs and their parents:

```
a/b/link
a/c/e/file
d/e/file
```

It feels a bit sprawly, so I want to see if I can be more concise. Will keep it in draft until I come have another look at it with fresh eyes.