### PR TITLE
rf: Rework public API to be more useful to downstream projects

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -161,6 +161,54 @@ git push -u origin feat/short-desc
 
 Open PR, set base branch to `dev`.
 
+### What to include in a pull request
+
+#### Test-driven development
+
+If you are fixing a bug, or adding a feature, it is strongly recommended to follow this pattern:
+
+1. Verify that tests pass: `deno test -A src`
+2. Write a test that fails (again, verify) because it reproduces your bug
+   or exercises the feature that does not yet exist.
+   This is a code-based specification of the behavior change.
+3. Commit the test before doing any further development.
+4. Fix the bug or implement the feature, and verify that tests now pass.
+
+Some rules to keep you honest:
+
+1. You can use several commits to implement your changes, but at the end, tests must pass.
+2. Changes to the tests must be in their own commits
+   and the commit message should explain why the specification has changed.
+
+By developing in this way, you ensure that the feature works as expected,
+and that there will be a problem if somebody else breaks the contract you wrote.
+
+#### Documentation
+
+As code changes, there is always a threat that documentation will no longer
+accurately describe the software.
+It is important to read the documentation to see whether
+the behavior you're changing is documented.
+If so, it needs to be updated.
+If not, consider whether you wish it already had been,
+and be the change you want to see in the world!
+
+Seriously, documentation is extremely important,
+and we know we don't do it enough.
+Contributions that are only documentation are very much appreciated.
+
+#### API
+
+We provide a programmatic API for downstream tools to build on the validator.
+The API lives in `src/api/`, and exports components that.
+
+If you're writing a new class, interface, type or function,
+consider whether it will be useful for downstream developers to have access.
+
+If you're tempted to create a `/tools` or `/util` submodule,
+it probably does not need to be in the API.
+If you really think it's important, let's talk.
+
 ### Conventions for branches, commits and changelogs
 
 The following conventions are intended to make contributions legible to other contributors
@@ -229,7 +277,7 @@ so we can focus on the content of the work.
 
 Even with these, it is possible that when you go to commit your changes,
 you have changed more than you intended to.
-One reason this can happen is that we might have forgetten to autoformat our code.
+One reason this can happen is that we might have forgotten to autoformat our code.
 
 One tool for this situation is `git add --patch` (or `-p`).
 This tool shows you each change in turn, allowing you to decide whether or not to
@@ -247,6 +295,22 @@ This will generally have the effect of introducing merge conflicts,
 so we may refrain from doing it for a while.
 If you're feeling the urge, it's best to ask!
 
+### Checking your work
+
+We use various tools to help us keep the repository in good shape.
+We already mentioned `deno fmt`.
+Additionally, we use:
+
+* `deno lint` - A tool that identifies potential bugs or maintenance debt
+* `deno check` - Run type checks without running the full test suite
+* `deno publish --dry-run --allow-dirty` - Test the repository for release readiness
+
+It's also a good idea to make sure that the docs build, if you're updating them:
+
+```console
+uv sync --locked --group=doc
+uv run make -C docs clean html
+```
 
 [link_git]: https://git-scm.com/
 [link_handbook]: https://guides.github.com/introduction/git-handbook/

--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -153,8 +153,10 @@ jobs:
           path: main
       - name: Commit to new branch
         run: |
-          mv main/main.js main/bids-validator.js .
-          git add main.js bids-validator.js
+          mv main/bids-validator.js .
+          git add bids-validator.js
+          # Probably only runs once, but avoids accidents. Can be removed in a bit.
+          git rm --ignore-unmatch main.js
           git commit -m "BLD: $VERSION [skip ci]" || true
         env:
           VERSION: ${{ needs.build.describe.version }}

--- a/build.ts
+++ b/build.ts
@@ -18,7 +18,7 @@ function getModuleDir(importMeta: ImportMeta): string {
 
 const dir = getModuleDir(import.meta);
 
-const MAIN_ENTRY = path.join(dir, 'src', 'main.ts')
+const MAIN_ENTRY = path.join(dir, 'src', 'web.ts')
 const CLI_ENTRY = path.join(dir, 'src', 'bids-validator.ts')
 
 const flags = parse(Deno.args, {

--- a/changelog.d/20260416_234603_markiewicz_api_surface_v3.md
+++ b/changelog.d/20260416_234603_markiewicz_api_surface_v3.md
@@ -1,0 +1,29 @@
+### Changed
+
+- Reorganized public API surface for v3. Library imports now use subpath-specific
+  entry points (`/validate`, `/files`, `/filetree`, `/files/deno`, `/files/browser`,
+  `/files/git`, `/issues`, `/output`, `/cli`). The root export (`.`) remains the
+  CLI entry point.
+
+### Added
+
+- New public subpaths expose primitives for building custom file sources:
+  `FileOpener`, `BIDSFile`, `FileTree`, `FileIgnoreRules`, `filesToTree`,
+  `subtree`, `loadBidsIgnore`, `readBidsIgnore`, and cross-environment openers
+  (`HTTPOpener`, `NullFileOpener`).
+- `detectErrors()` is now part of the public surface under `/validate`.
+- `UnknownIssueCodeError` — `DatasetIssues.add()` now throws a typed error
+  (instead of a plain `Error`) when called with an unrecognized issue code.
+- Stream helpers (`createUTF8Stream`, `streamFromUint8Array`, `streamFromString`,
+  `UnicodeDecodeError`) exported from `/files` for custom opener authors.
+
+### Deprecated
+
+- `@bids/validator/main` — use `/validate`, `/files/browser`, `/files/git` instead.
+  `main()` is preserved for back-compat; it has no replacement and will be removed
+  in v4.
+- `@bids/validator/options` — use `/validate` (types) and `/cli` (validateCommand)
+  instead. `parseOptions()` is preserved for back-compat; it has no replacement and
+  will be removed in v4.
+- `readFileTree` and `BIDSFileDeno` re-exported from `/files` — use `/files/deno`
+  instead.

--- a/changelog.d/20260417_102511_markiewicz_api_surface_v3.md
+++ b/changelog.d/20260417_102511_markiewicz_api_surface_v3.md
@@ -1,0 +1,4 @@
+### Infrastructure
+
+- The `main.js` build target has been renamed `web.js` for clarity.
+  It will no longer be saved to the `deno-build` branch.

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "name": "@bids/validator",
   "version": "3.0.0-dev",
   "exports": {
-    ".": "./src/bids-validator.ts",
+    ".": "./src/api/app.ts",
     "./validate": "./src/api/validate/mod.ts",
     "./files": "./src/api/files/mod.ts",
     "./filetree": "./src/api/filetree/mod.ts",

--- a/deno.json
+++ b/deno.json
@@ -1,13 +1,19 @@
 {
   "name": "@bids/validator",
-  "version": "2.4.2-dev",
+  "version": "3.0.0-dev",
   "exports": {
     ".": "./src/bids-validator.ts",
-    "./main": "./src/main.ts",
-    "./output": "./src/utils/output.ts",
-    "./files": "./src/files/deno.ts",
-    "./options": "./src/setup/options.ts",
-    "./issues": "./src/issues/datasetIssues.ts"
+    "./validate": "./src/api/validate/mod.ts",
+    "./files": "./src/api/files/mod.ts",
+    "./filetree": "./src/api/filetree/mod.ts",
+    "./files/deno": "./src/api/files/deno/mod.ts",
+    "./files/browser": "./src/api/files/browser/mod.ts",
+    "./files/git": "./src/api/files/git/mod.ts",
+    "./issues": "./src/api/issues/mod.ts",
+    "./output": "./src/api/output/mod.ts",
+    "./cli": "./src/api/cli/mod.ts",
+    "./main": "./src/api/main/mod.ts",
+    "./options": "./src/api/options/mod.ts"
   },
   "exclude": [
     "docs/",

--- a/docs/dev/using-the-api.md
+++ b/docs/dev/using-the-api.md
@@ -27,8 +27,8 @@ The smallest useful program loads a dataset from disk into a `FileTree`
 and runs `validate` against it:
 
 ```ts
-import { readFileTree } from '@bids/validator/files'
-import { validate } from '@bids/validator/main'
+import { readFileTree } from '@bids/validator/files/deno'
+import { validate } from '@bids/validator/validate'
 
 const datasetPath = '/path/to/dataset'
 const tree = await readFileTree(datasetPath)
@@ -98,7 +98,8 @@ drag-and-drop event rather than a path on disk. Use `fileListToTree`
 to construct a `FileTree` directly from the file list:
 
 ```ts
-import { fileListToTree, validate } from '@bids/validator/main'
+import { fileListToTree } from '@bids/validator/files/browser'
+import { validate } from '@bids/validator/validate'
 
 async function validateUserSelection(files: File[]) {
   const tree = await fileListToTree(files)

--- a/local-run
+++ b/local-run
@@ -1,4 +1,4 @@
 #!/usr/bin/env -S deno run --allow-read --allow-write --allow-env --allow-net --allow-run
 // This script runs the local copy of the validator, intended as a development aid.
 // You generally should run `deno run -A jsr:@bids/validator`
-import './src/bids-validator.ts'
+import './src/api/app.ts'

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,0 +1,17 @@
+/**
+ * The command-line interface for the BIDS Validator.
+ *
+ * @example
+ * ```bash
+ * deno -A jsr:@bids/validator [OPTIONS] /path/to/dataset
+ * ```
+ */
+import { main } from '@bids/validator/main'
+import { detectErrors } from '@bids/validator/validate'
+
+const result = await main()
+
+if (detectErrors(result)) {
+  Deno.exit(16)
+}
+Deno.exit(0)

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,10 +1,32 @@
 /**
+ * # BIDS Validator
+ *
  * The command-line interface for the BIDS Validator.
  *
- * @example
+ * Importing this module runs the BIDS validator using Deno APIs.
+ *
+ * ## Library API
+ *
+ * For programmatic use, import from the subpath modules:
+ *
+ * | Module                                      | Purpose                                       |
+ * | ------------------------------------------- | --------------------------------------------- |
+ * | [/validate]{@linkcode ./validate}           | Run validation and inspect results            |
+ * | [/files]{@linkcode ./files}                 | Tools for building and typing file accessors  |
+ * | [/files/browser]{@linkcode ./files/browser} | Access files using the browser File API       |
+ * | [/files/deno]{@linkcode ./files/deno}       | Access filesystem files using Deno            |
+ * | [/files/git]{@linkcode ./files/git}         | Access files in git/git-annex repositories    |
+ * | [/filetree]{@linkcode ./filetree}           | Build and manipulate file trees               |
+ * | [/issues]{@linkcode ./issues}               | Issue types and the `DatasetIssues` container |
+ * | [/output]{@linkcode ./output}               | Result formatting for CLIs and UIs            |
+ * | [/cli]{@linkcode ./cli}                     | Extensible Cliffy command (`validateCommand`) |
+ *
+ * @example Command-line usage
  * ```bash
  * deno -A jsr:@bids/validator [OPTIONS] /path/to/dataset
  * ```
+ *
+ * @module
  */
 import { main } from '@bids/validator/main'
 import { detectErrors } from '@bids/validator/validate'

--- a/src/api/cli/mod.ts
+++ b/src/api/cli/mod.ts
@@ -1,0 +1,1 @@
+export { validateCommand } from '../../setup/options.ts'

--- a/src/api/files/browser/mod.ts
+++ b/src/api/files/browser/mod.ts
@@ -1,0 +1,2 @@
+export { BIDSFileBrowser, fileListToTree } from '../../../files/browser.ts'
+export { BrowserFileOpener } from '../../../files/openers.ts'

--- a/src/api/files/deno/mod.ts
+++ b/src/api/files/deno/mod.ts
@@ -1,0 +1,2 @@
+export { BIDSFileDeno, readFileTree } from '../../../files/deno.ts'
+export { FsFileOpener } from '../../../files/openers.ts'

--- a/src/api/files/git/mod.ts
+++ b/src/api/files/git/mod.ts
@@ -1,0 +1,1 @@
+export { AnnexedGitFileOpener, GitFileOpener, readGitTree } from '../../../files/git.ts'

--- a/src/api/files/mod.ts
+++ b/src/api/files/mod.ts
@@ -1,0 +1,15 @@
+export { BIDSFile } from '../../types/filetree.ts'
+export type { FileOpener, SymlinkReason, UnresolvedLink } from '../../types/filetree.ts'
+export { HTTPOpener, NullFileOpener } from '../../files/openers.ts'
+export {
+  createUTF8Stream,
+  streamFromString,
+  streamFromUint8Array,
+  UnicodeDecodeError,
+} from '../../files/streams.ts'
+
+// Back-compat — removed at v4.0
+/** @deprecated Import from '@bids/validator/files/deno' instead. */
+export { readFileTree } from '../../files/deno.ts'
+/** @deprecated Import from '@bids/validator/files/deno' instead. */
+export { BIDSFileDeno } from '../../files/deno.ts'

--- a/src/api/filetree/mod.ts
+++ b/src/api/filetree/mod.ts
@@ -1,0 +1,3 @@
+export { FileTree } from '../../types/filetree.ts'
+export { filesToTree, loadBidsIgnore, subtree } from '../../files/filetree.ts'
+export { FileIgnoreRules, readBidsIgnore } from '../../files/ignore.ts'

--- a/src/api/issues/mod.ts
+++ b/src/api/issues/mod.ts
@@ -1,3 +1,3 @@
-export { DatasetIssues } from '../../issues/datasetIssues.ts'
+export { DatasetIssues, UnknownIssueCodeError } from '../../issues/datasetIssues.ts'
 export { filterIssue } from '../../types/issues.ts'
 export type { Issue, IssueDefinition, IssueFile, Severity } from '../../types/issues.ts'

--- a/src/api/issues/mod.ts
+++ b/src/api/issues/mod.ts
@@ -1,0 +1,3 @@
+export { DatasetIssues } from '../../issues/datasetIssues.ts'
+export { filterIssue } from '../../types/issues.ts'
+export type { Issue, IssueDefinition, IssueFile, Severity } from '../../types/issues.ts'

--- a/src/api/main/mod.ts
+++ b/src/api/main/mod.ts
@@ -1,0 +1,17 @@
+/**
+ * @deprecated The ./main entry point is deprecated. Use the specific
+ * subpath imports instead:
+ * - validate, getVersion, ValidationResult → '@bids/validator/validate'
+ * - fileListToTree → '@bids/validator/files/browser'
+ */
+
+/** @deprecated Use validate from '@bids/validator/validate'. */
+export { validate } from '../../validators/bids.ts'
+/** @deprecated Use getVersion from '@bids/validator/validate'. */
+export { getVersion } from '../../version.ts'
+/** @deprecated Use ValidationResult from '@bids/validator/validate'. */
+export type { ValidationResult } from '../../types/validation-result.ts'
+/** @deprecated Use fileListToTree from '@bids/validator/files/browser'. */
+export { fileListToTree } from '../../files/browser.ts'
+/** @deprecated Use validate() and friends from '@bids/validator/validate' instead. main() will be removed in v4. */
+export { main } from '../../main.ts'

--- a/src/api/options/mod.ts
+++ b/src/api/options/mod.ts
@@ -1,0 +1,15 @@
+/**
+ * @deprecated The ./options entry point is deprecated. Use:
+ * - Config, ValidatorOptions → '@bids/validator/validate'
+ * - validateCommand → '@bids/validator/cli'
+ * parseOptions has no replacement and will be removed in v4.
+ */
+
+/** @deprecated Use Config from '@bids/validator/validate'. */
+export type { Config } from '../../setup/options.ts'
+/** @deprecated Use ValidatorOptions from '@bids/validator/validate'. */
+export type { ValidatorOptions } from '../../setup/options.ts'
+/** @deprecated Use validateCommand from '@bids/validator/cli'. */
+export { validateCommand } from '../../setup/options.ts'
+/** @deprecated parseOptions will be removed in v4. No replacement — use validate() with your own options. */
+export { parseOptions } from '../../setup/options.ts'

--- a/src/api/output/mod.ts
+++ b/src/api/output/mod.ts
@@ -1,0 +1,1 @@
+export { consoleFormat, resultToJSONStr } from '../../utils/output.ts'

--- a/src/api/surface.test.ts
+++ b/src/api/surface.test.ts
@@ -1,0 +1,31 @@
+import * as _validate from './validate/mod.ts'
+import * as _files from './files/mod.ts'
+import * as _filetree from './filetree/mod.ts'
+import * as _filesDeno from './files/deno/mod.ts'
+import * as _filesBrowser from './files/browser/mod.ts'
+import * as _filesGit from './files/git/mod.ts'
+import * as _issues from './issues/mod.ts'
+import * as _output from './output/mod.ts'
+import * as _cli from './cli/mod.ts'
+import * as _mainDeprecated from './main/mod.ts'
+import * as _optionsDeprecated from './options/mod.ts'
+
+Deno.test('public API surface loads', () => {
+  // Reference each namespace so that the imports are treated as value
+  // imports rather than type-only imports. If a module is removed or a
+  // re-export is dropped the TypeScript compiler will reject this file
+  // and CI will fail.
+  void [
+    _validate,
+    _files,
+    _filetree,
+    _filesDeno,
+    _filesBrowser,
+    _filesGit,
+    _issues,
+    _output,
+    _cli,
+    _mainDeprecated,
+    _optionsDeprecated,
+  ]
+})

--- a/src/api/validate/mod.ts
+++ b/src/api/validate/mod.ts
@@ -1,0 +1,9 @@
+export { validate } from '../../validators/bids.ts'
+export { detectErrors } from '../../summary/summary.ts'
+export { getVersion } from '../../version.ts'
+export type {
+  SubjectMetadata,
+  SummaryOutput,
+  ValidationResult,
+} from '../../types/validation-result.ts'
+export type { Config, ValidatorOptions } from '../../setup/options.ts'

--- a/src/bids-validator.ts
+++ b/src/bids-validator.ts
@@ -1,9 +1,4 @@
-import { main } from './main.ts'
-import { detectErrors } from './summary/summary.ts'
-
-const result = await main()
-
-if (detectErrors(result)) {
-  Deno.exit(16)
-}
-Deno.exit(0)
+/**
+ * Shim to support running from `$REPO/src/bids-validator.ts`
+ */
+import '@bids/validator'

--- a/src/files/browser.ts
+++ b/src/files/browser.ts
@@ -4,7 +4,11 @@ import { FileIgnoreRules } from './ignore.ts'
 import { BrowserFileOpener } from './openers.ts'
 
 /**
- * Browser implement of BIDSFile wrapping native File/FileList types
+ * Browser-specific {@link BIDSFile} wrapping the native `File` API.
+ *
+ * @param file - A `File` obtained from an `<input webkitdirectory>` element.
+ * @param ignore - Ignore rules for this file.
+ * @param parent - Parent directory node.
  */
 export class BIDSFileBrowser extends BIDSFile {
   constructor(file: File, ignore: FileIgnoreRules, parent?: FileTree) {
@@ -16,7 +20,11 @@ export class BIDSFileBrowser extends BIDSFile {
 }
 
 /**
- * Convert from FileList (created with webkitDirectory: true) to FileTree for validator use
+ * Convert a browser `File[]` (from `<input webkitdirectory>`) into a
+ * {@link FileTree} suitable for validation.
+ *
+ * @param files - Files selected via the browser file picker.
+ * @returns The root `FileTree` with `.bidsignore` rules applied.
  */
 export function fileListToTree(files: File[]): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -12,6 +12,14 @@ import { gitdirFromLink, parseAnnexKey } from './repo.ts'
 import { AnnexedGitFileOpener } from './git.ts'
 import fs from 'node:fs'
 
+/**
+ * Deno-specific {@link BIDSFile} backed by the local filesystem.
+ *
+ * @param datasetPath - Absolute path to the dataset root on disk.
+ * @param path - Dataset-relative POSIX path of the file.
+ * @param ignore - Optional ignore rules for this file.
+ * @param parent - Parent directory node.
+ */
 export class BIDSFileDeno extends BIDSFile {
   constructor(datasetPath: string, path: string, ignore?: FileIgnoreRules, parent?: FileTree) {
     super(path, new FsFileOpener(datasetPath, path), ignore, parent)
@@ -109,7 +117,17 @@ async function _readFileTree({
 }
 
 /**
- * Read in the target directory structure and return a FileTree
+ * Recursively walk a local directory and build a {@link FileTree}.
+ *
+ * Symlinks to git-annex objects are detected and wrapped with
+ * {@link AnnexedGitFileOpener}. Broken or cyclic symlinks are recorded
+ * as unresolved links on the tree.
+ *
+ * @param rootPath - Absolute path to the dataset root directory.
+ * @param prune - Optional rules for directories to skip entirely.
+ * @param preferredRemote - Preferred git-annex remote name for fetching
+ *   content that is not locally present.
+ * @returns The root `FileTree` with `.bidsignore` rules applied.
  */
 export async function readFileTree(
   rootPath: string,

--- a/src/files/filetree.ts
+++ b/src/files/filetree.ts
@@ -25,6 +25,17 @@ function descendTo(root: FileTree, dir: string, ignore: FileIgnoreRules): FileTr
   return current
 }
 
+/**
+ * Build a {@link FileTree} from a flat list of {@link BIDSFile} objects.
+ *
+ * Intermediate directory nodes are created as needed. Any unresolved
+ * symlinks are attached to the appropriate directory.
+ *
+ * @param fileList - Files to insert into the tree.
+ * @param ignore - Optional ignore rules applied to every node.
+ * @param unresolvedLinks - Symlinks that could not be followed.
+ * @returns The root `FileTree`.
+ */
 export function filesToTree(
   fileList: BIDSFile[],
   ignore?: FileIgnoreRules,
@@ -78,6 +89,16 @@ function rerootTree({
   return tree
 }
 
+/**
+ * Re-root a sub-directory as an independent {@link FileTree}.
+ *
+ * All paths inside the returned tree are relative to `filetree` rather
+ * than the original dataset root. `.bidsignore` rules are reloaded from
+ * the new root.
+ *
+ * @param filetree - The directory node to promote to root.
+ * @returns A new `FileTree` rooted at `filetree`.
+ */
 export function subtree(filetree: FileTree): Promise<FileTree> {
   const ignore = new FileIgnoreRules([])
   return loadBidsIgnore(rerootTree({ oldTree: filetree, newRoot: filetree.path, ignore }), ignore)

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -30,6 +30,15 @@ export interface GitOptions {
   cache: object
 }
 
+/**
+ * {@link FileOpener} that reads blob content from a git object store.
+ *
+ * Content is loaded lazily on first access via `isomorphic-git`.
+ *
+ * @param oid - Git object ID of the blob.
+ * @param size - Blob size in bytes.
+ * @param gitOptions - Repository-level git configuration.
+ */
 export class GitFileOpener implements FileOpener {
   oid: string
   size: number
@@ -287,10 +296,20 @@ async function resolveSymlinkInTree(
 }
 
 /**
- * Walk a git ref and build a FileTree from all blobs found.
+ * Walk a git ref and build a {@link FileTree} from all blobs found.
  *
- * Uses isomorphic-git walk() with TREE to enumerate files at the given ref,
- * creates BIDSFile objects backed by GitFileOpener, and assembles via filesToTree().
+ * Works with both work-tree checkouts and bare repositories.
+ * `ref` can be a branch name, tag, commit SHA, abbreviated SHA, or tree
+ * SHA. Symlinks within the tree are resolved where possible; annex
+ * pointer files are wrapped with {@link AnnexedGitFileOpener}.
+ *
+ * @param repoPath - Path to the repository (work-tree or bare `.git` dir).
+ * @param ref - Git ref to walk; defaults to `"HEAD"`.
+ * @param prune - Optional rules for paths to skip entirely.
+ * @param preferredRemote - Preferred git-annex remote for fetching content.
+ * @returns The root `FileTree` with `.bidsignore` rules applied.
+ * @throws {Error} If `repoPath` is not a git repository, has no commits,
+ *   or `ref` cannot be resolved.
  */
 export async function readGitTree(
   repoPath: string,

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -2,6 +2,12 @@ import type { BIDSFile } from '../types/filetree.ts'
 import { default as ignore } from '@ignore'
 import type { Ignore } from '@ignore'
 
+/**
+ * Read a `.bidsignore` file and return its lines as ignore patterns.
+ *
+ * @param file - The `.bidsignore` file to read.
+ * @returns An array of gitignore-style patterns.
+ */
 export async function readBidsIgnore(file: BIDSFile): Promise<string[]> {
   const value = await file.text()
   if (value) {
@@ -22,7 +28,11 @@ const defaultIgnores = [
 ]
 
 /**
- * Deno implementation of .bidsignore style rules
+ * Gitignore-style path matcher for `.bidsignore` rules.
+ *
+ * @param config - Array of gitignore-style patterns.
+ * @param addDefaults - When `true` (the default), standard BIDS ignores
+ *   (`.git**`, `sourcedata/`, `code/`, etc.) are prepended.
  */
 export class FileIgnoreRules {
   #ignore: Ignore

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -2,7 +2,7 @@ import type { BIDSFile } from '../types/filetree.ts'
 import { default as ignore } from '@ignore'
 import type { Ignore } from '@ignore'
 
-export async function readBidsIgnore(file: BIDSFile) {
+export async function readBidsIgnore(file: BIDSFile): Promise<string[]> {
   const value = await file.text()
   if (value) {
     const lines = value.split('\n')

--- a/src/files/openers.ts
+++ b/src/files/openers.ts
@@ -108,6 +108,12 @@ class HttpError extends Error {
   }
 }
 
+/**
+ * {@link FileOpener} that fetches content over HTTP with automatic retries.
+ *
+ * @param url - The URL to fetch content from.
+ * @param size - Known file size in bytes, or `-1` if unknown.
+ */
 export class HTTPOpener implements FileOpener {
   url: string
   size: number
@@ -167,6 +173,14 @@ export class HTTPOpener implements FileOpener {
   }
 }
 
+/**
+ * No-op {@link FileOpener} that returns empty content.
+ *
+ * Used as a placeholder when file content is unavailable (e.g. an
+ * unresolvable git-annex object).
+ *
+ * @param size - Reported file size; defaults to `0`.
+ */
 export class NullFileOpener implements FileOpener {
   size: number
   constructor(size = 0) {

--- a/src/files/openers.ts
+++ b/src/files/openers.ts
@@ -172,7 +172,7 @@ export class NullFileOpener implements FileOpener {
   constructor(size = 0) {
     this.size = size
   }
-  stream = () =>
+  stream = (): Promise<ReadableStream<Uint8Array<ArrayBuffer>>> =>
     Promise.resolve(
       new ReadableStream({
         start(controller) {
@@ -180,6 +180,7 @@ export class NullFileOpener implements FileOpener {
         },
       }),
     )
-  text = () => Promise.resolve('')
-  readBytes = (_size: number, _offset?: number) => Promise.resolve(new Uint8Array())
+  text = (): Promise<string> => Promise.resolve('')
+  readBytes = (_size: number, _offset?: number): Promise<Uint8Array<ArrayBuffer>> =>
+    Promise.resolve(new Uint8Array())
 }

--- a/src/files/streams.ts
+++ b/src/files/streams.ts
@@ -54,14 +54,20 @@ export class UTF8StreamTransformer implements Transformer<Uint8Array, string> {
 }
 
 /**
- * Creates a TransformStream that validates and decodes UTF-8 text
+ * Create a `TransformStream` that validates and decodes UTF-8 text.
+ *
+ * @param options - Decoder options; set `fatal: true` to throw on invalid bytes.
+ * @returns A transform stream from raw bytes to decoded strings.
  */
 export function createUTF8Stream(options = { fatal: false }): TransformStream<Uint8Array, string> {
   return new TransformStream(new UTF8StreamTransformer(options))
 }
 
 /**
- * Creates a byte stream from a Uint8Array
+ * Create a single-chunk `ReadableStream` from a `Uint8Array`.
+ *
+ * @param arr - The byte array to wrap.
+ * @returns A readable stream that emits `arr` and closes.
  */
 export function streamFromUint8Array<T extends ArrayBufferLike>(
   arr: Uint8Array<T>,
@@ -75,7 +81,10 @@ export function streamFromUint8Array<T extends ArrayBufferLike>(
 }
 
 /**
- * Creates a byte stream from a string
+ * Create a single-chunk `ReadableStream` by UTF-8-encoding a string.
+ *
+ * @param str - The string to encode.
+ * @returns A readable stream of the encoded bytes.
  */
 export function streamFromString(str: string): ReadableStream<Uint8Array<ArrayBuffer>> {
   return streamFromUint8Array(new TextEncoder().encode(str) as Uint8Array<ArrayBuffer>)

--- a/src/files/streams.ts
+++ b/src/files/streams.ts
@@ -56,7 +56,7 @@ export class UTF8StreamTransformer implements Transformer<Uint8Array, string> {
 /**
  * Creates a TransformStream that validates and decodes UTF-8 text
  */
-export function createUTF8Stream(options = { fatal: false }) {
+export function createUTF8Stream(options = { fatal: false }): TransformStream<Uint8Array, string> {
   return new TransformStream(new UTF8StreamTransformer(options))
 }
 

--- a/src/issues/datasetIssues.test.ts
+++ b/src/issues/datasetIssues.test.ts
@@ -1,6 +1,6 @@
-import { assert, assertEquals, assertThrows } from '@std/assert'
+import { assert, assertEquals, assertStringIncludes, assertThrows } from '@std/assert'
 import { pathsToTree } from '../files/filetree.test.ts'
-import { DatasetIssues } from './datasetIssues.ts'
+import { DatasetIssues, UnknownIssueCodeError } from './datasetIssues.ts'
 
 Deno.test('DatasetIssues management class', async (t) => {
   await t.step('Constructor succeeds', () => {
@@ -55,4 +55,16 @@ Deno.test('DatasetIssues management class', async (t) => {
     assert(code1 !== undefined)
     assertEquals(code1.size, 2)
   })
+})
+
+Deno.test('DatasetIssues.add() throws UnknownIssueCodeError for unrecognized code', () => {
+  const issues = new DatasetIssues()
+  const error = assertThrows(
+    () => issues.add({ code: 'TOTALLY_FAKE_CODE_12345' }),
+    UnknownIssueCodeError,
+  )
+  // Verify the error message is preserved
+  assertStringIncludes(error.message, 'TOTALLY_FAKE_CODE_12345')
+  // Verify the code property is set
+  assertEquals(error.code, 'TOTALLY_FAKE_CODE_12345')
 })

--- a/src/issues/datasetIssues.ts
+++ b/src/issues/datasetIssues.ts
@@ -57,8 +57,8 @@ export class DatasetIssues {
    * @param codeMessage - Optional human-readable description for
    *   `issue.code`. Required when `issue.code` is not in the non-schema
    *   issue catalogue.
-   * @throws {Error} If `codeMessage` is not provided and `issue.code`
-   *   is not a key in the non-schema issue catalogue.
+   * @throws {UnknownIssueCodeError} If `codeMessage` is not provided and
+   *   `issue.code` is not a key in the non-schema issue catalogue.
    */
   add(issue: Issue, codeMessage?: string) {
     // Ensure only relevant fields are kept, for protection when working with

--- a/src/issues/datasetIssues.ts
+++ b/src/issues/datasetIssues.ts
@@ -7,6 +7,20 @@ export type { Issue, IssueDefinition, IssueFile, Severity }
 // Code is deprecated, return something unusual but JSON serializable
 const _CODE_DEPRECATED = Number.MIN_SAFE_INTEGER
 
+/**
+ * Thrown by {@link DatasetIssues.add} when the caller supplies an issue
+ * whose `code` is not defined in the non-schema issue catalogue and does
+ * not pass a `codeMessage` argument to describe it.
+ */
+export class UnknownIssueCodeError extends Error {
+  readonly code: string
+  constructor(code: string) {
+    super(`key: ${code} does not exist in non-schema issues definitions`)
+    this.name = 'UnknownIssueCodeError'
+    this.code = code
+  }
+}
+
 type Group = Map<Issue[keyof Issue], DatasetIssues | Group | undefined>
 
 /**
@@ -55,9 +69,7 @@ export class DatasetIssues {
         codeMessage = nonSchemaIssues[issue.code].reason
         issue.severity ??= nonSchemaIssues[issue.code].severity
       } else {
-        throw new Error(
-          `key: ${issue.code} does not exist in non-schema issues definitions`,
-        )
+        throw new UnknownIssueCodeError(issue.code)
       }
     }
     issue.severity ??= 'error'

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,15 +3,12 @@ import type { Config } from './setup/options.ts'
 import * as colors from '@std/fmt/colors'
 import { readFileTree } from './files/deno.ts'
 import { readGitTree } from './files/git.ts'
-import { fileListToTree } from './files/browser.ts'
 import { FileIgnoreRules } from './files/ignore.ts'
 import { resolve } from '@std/path'
 import { validate } from './validators/bids.ts'
 import { consoleFormat, resultToJSONStr } from './utils/output.ts'
 import { setupLogging } from './utils/logger.ts'
 import type { ValidationResult } from './types/validation-result.ts'
-export type { ValidationResult } from './types/validation-result.ts'
-export { getVersion } from './version.ts'
 
 /**
  * Validation entrypoint intended for command line usage with Deno
@@ -63,5 +60,3 @@ export async function main(): Promise<ValidationResult> {
 
   return schemaResult
 }
-
-export { fileListToTree, readGitTree, validate }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,17 @@
-import { parseOptions } from './setup/options.ts'
-import type { Config } from './setup/options.ts'
-import * as colors from '@std/fmt/colors'
-import { readFileTree } from './files/deno.ts'
-import { readGitTree } from './files/git.ts'
-import { FileIgnoreRules } from './files/ignore.ts'
+/* External */
 import { resolve } from '@std/path'
-import { validate } from './validators/bids.ts'
-import { consoleFormat, resultToJSONStr } from './utils/output.ts'
+import * as colors from '@std/fmt/colors'
+/* Exported API */
+import { readFileTree } from '@bids/validator/files/deno'
+import { readGitTree } from '@bids/validator/files/git'
+import { FileIgnoreRules } from '@bids/validator/filetree'
+import { validate } from '@bids/validator/validate'
+import { consoleFormat, resultToJSONStr } from '@bids/validator/output'
+/* Purely internal */
 import { setupLogging } from './utils/logger.ts'
-import type { ValidationResult } from './types/validation-result.ts'
+import { parseOptions } from './setup/options.ts'
+/* Types */
+import type { Config, ValidationResult } from '@bids/validator/validate'
 
 /**
  * Validation entrypoint intended for command line usage with Deno

--- a/src/summary/summary.ts
+++ b/src/summary/summary.ts
@@ -171,6 +171,15 @@ export class Summary {
   }
 }
 
+/**
+ * Check whether a validation result contains any errors.
+ *
+ * Returns `true` if the result's issues include at least one error, or if
+ * any derivative result (when recursive validation is used) contains errors.
+ *
+ * @param result - The validation result to check.
+ * @returns `true` if any error-severity issues exist.
+ */
 export function detectErrors(result: ValidationResult): boolean {
   return result.issues.get({ severity: 'error' }).length > 0 ||
     Object.values(result.derivativesSummary ?? {}).some((res) => detectErrors(res))

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -1,6 +1,7 @@
 import { basename } from '@std/path'
 import { FileIgnoreRules } from '../files/ignore.ts'
 
+/** Contract for reading file content as a stream, text, or byte slice. */
 export interface FileOpener {
   size: number
   stream: () => Promise<ReadableStream<Uint8Array<ArrayBuffer>>>
@@ -8,6 +9,7 @@ export interface FileOpener {
   readBytes: (size: number, offset?: number) => Promise<Uint8Array<ArrayBuffer>>
 }
 
+/** Reason a symlink could not be resolved during tree construction. */
 export type SymlinkReason =
   | 'broken'
   | 'cycle'
@@ -15,12 +17,25 @@ export type SymlinkReason =
   | 'out-of-tree'
   | 'directory-unsupported'
 
+/** A symlink that could not be followed, with the reason it was skipped. */
 export interface UnresolvedLink {
   path: string
   target: string
   reason: SymlinkReason
 }
 
+/**
+ * A single file in a BIDS dataset.
+ *
+ * Wraps a {@link FileOpener} that provides lazy access to the file's
+ * content. The `parent` property is held via `WeakRef` so that a file
+ * does not prevent its containing {@link FileTree} from being collected.
+ *
+ * @param path - Dataset-relative POSIX path (e.g. `"/sub-01/anat/sub-01_T1w.nii.gz"`).
+ * @param opener - Provides `stream`, `text`, and `readBytes` access.
+ * @param ignore - Ignore rules or a boolean override for this file.
+ * @param parent - The directory node that contains this file.
+ */
 export class BIDSFile {
   name: string
   path: string
@@ -76,7 +91,16 @@ export class BIDSFile {
 }
 
 /**
- * Abstract FileTree for all environments (Deno, Browser, Python)
+ * Directory node in a BIDS dataset tree.
+ *
+ * Works across all environments (Deno, browser, Python). The `parent`
+ * property is held via `WeakRef` to avoid preventing garbage collection of
+ * ancestor nodes.
+ *
+ * @param path - Dataset-relative POSIX path of this directory.
+ * @param name - The directory's own name (final path component).
+ * @param parent - Parent directory node, if any.
+ * @param ignore - Ignore rules applied when testing paths under this tree.
  */
 export class FileTree {
   // Relative path to this FileTree location
@@ -136,6 +160,15 @@ export class FileTree {
     return this._get(path.split('/'))
   }
 
+  /**
+   * Test whether a path exists in this tree.
+   *
+   * Side-effect: sets `viewed = true` on the matched node so that
+   * validators can later detect unreferenced files.
+   *
+   * @param parts - Path segments to look up (e.g. `['sub-01', 'anat', 'sub-01_T1w.nii.gz']`).
+   * @returns `true` if the path resolves to a file or directory.
+   */
   contains(parts: string[]): boolean {
     const value = this._get(parts)
     return value ? (value.viewed = true) : false

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -93,7 +93,7 @@ export class BIDSFile {
 /**
  * Directory node in a BIDS dataset tree.
  *
- * Works across all environments (Deno, browser, Python). The `parent`
+ * Works across all environments (Deno, browser, git). The `parent`
  * property is held via `WeakRef` to avoid preventing garbage collection of
  * ancestor nodes.
  *

--- a/src/types/validation-result.ts
+++ b/src/types/validation-result.ts
@@ -1,5 +1,6 @@
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
 
+/** Per-participant demographics extracted from `participants.tsv`. */
 export interface SubjectMetadata {
   participantId: string
   age?: number | null | '89+'
@@ -13,6 +14,7 @@ export interface SubjectMetadata {
     TracerRadionuclide: {},
 */
 
+/** Aggregated run statistics produced by a validation pass. */
 export interface SummaryOutput {
   sessions: string[]
   subjects: string[]

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -16,9 +16,11 @@ interface LoggingOptions {
 }
 
 /**
- * Format for Unix consoles
+ * Format a validation result for Unix console display.
  *
- * Returns the full output string with newlines
+ * @param result - The validation result to format.
+ * @param options - Logging options; `verbose` includes extra detail per issue.
+ * @returns The full ANSI-coloured output string with newlines.
  */
 export function consoleFormat(
   result: ValidationResult,
@@ -247,6 +249,16 @@ function helpUrl(code: string): string {
   return `https://neurostars.org/search?q=${code}`
 }
 
+/**
+ * Serialize a validation result to a JSON string.
+ *
+ * Circular `parent` references are stripped and `Map` instances are
+ * converted to plain objects during serialization.
+ *
+ * @param result - The validation result to serialize.
+ * @param pretty - When `true`, indent with two spaces.
+ * @returns The JSON string.
+ */
 export function resultToJSONStr(result: ValidationResult, pretty: boolean = false): string {
   const indent = pretty ? 2 : 0
   return JSON.stringify(result, (_key, value) => {

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -6,10 +6,17 @@ import * as colors from '@std/fmt/colors'
 import { format as prettyBytes } from '@std/fmt/bytes'
 import { marked } from 'marked'
 import supportsHyperlinks from 'supports-hyperlinks'
-import ansiEscapes from 'ansi-escapes'
 import type { SummaryOutput, ValidationResult } from '../types/validation-result.ts'
 import type { Issue, Severity } from '../types/issues.ts'
 import type { DatasetIssues } from '../issues/datasetIssues.ts'
+
+// ansi-escapes attempts to use the system permissions on Windows at import time.
+// Limiting the frequency of that request to times when it is needed is nicer to users
+// and avoids the need to give the permission to tests on Windows CI.
+let ansiEscapes: typeof import('ansi-escapes') | undefined
+if (supportsHyperlinks.stdout) {
+  ansiEscapes = await import('ansi-escapes')
+}
 
 interface LoggingOptions {
   verbose: boolean
@@ -79,7 +86,7 @@ function renderTokens(tokenList: any[]): string {
 
       case 'link':
         // Using the library to check for stdout support
-        if (supportsHyperlinks.stdout) {
+        if (ansiEscapes) {
           return ansiEscapes.link(token.text, token.href)
         } else {
           // Fallback for terminals without support

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -69,8 +69,8 @@ const perDSChecks: DSCheckFunction[] = [
  *
  * @example
  * ```ts
- * import { readFileTree } from '@bids/validator/files'
- * import { validate } from '@bids/validator/main'
+ * import { readFileTree } from '@bids/validator/files/deno'
+ * import { validate } from '@bids/validator/validate'
  *
  * const tree = await readFileTree('/path/to/dataset')
  * const result = await validate(tree, {

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,0 +1,7 @@
+/**
+ * Entrypoint to create a bundle that can be imported in the web app
+ *
+ * Used in /web/src/App.tsx
+ */
+export { fileListToTree } from '@bids/validator/files/browser'
+export { getVersion, validate, type ValidationResult } from '@bids/validator/validate'

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,7 +3,7 @@ import "./App.css"
 import { directoryOpen } from "https://esm.sh/browser-fs-access@0.35.0"
 import confetti from 'https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.module.mjs';
 import Markdown from "react-markdown"
-import { fileListToTree, validate, getVersion } from "../dist/validator/main.js"
+import { fileListToTree, validate, getVersion } from "../dist/validator/web.js"
 import type { ValidationResult } from "../../src/types/validation-result.ts"
 import { Collapse } from "./Collapse.tsx"
 import { Summary } from "./Summary.tsx"

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -14,7 +14,7 @@ function workaroundAssetImportMetaUrlPluginBug() {
   return {
     name: "vite-workaround-import-glob",
     transform(src, id) {
-      if (id.includes('validator/main.js')) {
+      if (id.includes('validator/web.js')) {
         return src.replace(", import.meta.url", "")
       } else {
         return null


### PR DESCRIPTION
A lot of things added recently haven't been considered for the API. They've either been added because they happen to be in an exported file, or not because they weren't. The current API is also not very principled about what goes where. Sometimes we just re-exported a thing from a module in the API because it was imported into one of the modules.

This proposal breaks things down into the following categories:

| Module                                      | Purpose                                       | 
| ------------------------------------------- | --------------------------------------------- | 
| `/validate`           | Run validation and inspect results            |                       
| `/files`                 | Tools for building and typing file accessors  |                    
| `/files/browser` | Access files using the browser File API       |                            
| `/files/deno`       | Access filesystem files using Deno            |                         
| `/files/git`         | Access files in git/git-annex repositories    |                        
| `/filetree`           | Build and manipulate file trees               |                       
| `/issues`               | Issue types and the `DatasetIssues` container |                     
| `/output`               | Result formatting for CLIs and UIs            |                     
| `/cli`                     | Extensible Cliffy command (`validateCommand`) |                  

I used the strategy of creating a separate `api/` directory, that *only* exports from the original locations, which will allow us to reorganize freely without modifying anything but API pointers.

There's some potential for dog-wagging here, as thinking about the API this way might help us reorganize so that the things that each of these exports is sufficiently siloed (except `/validate`, obviously) to support tree-shaking. For example, I think it's clear that the file openers for the browser and deno should be moved into their respective modules, instead of a common `openers.ts`.

<details><summary>Here are the exports:</summary>

```
repos/bids-validator/src/api/cli/mod.ts
     1:	export { validateCommand } from '../../setup/options.ts'

repos/bids-validator/src/api/files/browser/mod.ts
     1:	export { BIDSFileBrowser, fileListToTree } from '../../../files/browser.ts'
     2:	export { BrowserFileOpener } from '../../../files/openers.ts'

repos/bids-validator/src/api/files/deno/mod.ts
     1:	export { BIDSFileDeno, readFileTree } from '../../../files/deno.ts'
     2:	export { FsFileOpener } from '../../../files/openers.ts'

repos/bids-validator/src/api/files/git/mod.ts
     1:	export { AnnexedGitFileOpener, GitFileOpener, readGitTree } from '../../../files/git.ts'

repos/bids-validator/src/api/files/mod.ts
     1:	export { BIDSFile } from '../../types/filetree.ts'
     3:	export { HTTPOpener, NullFileOpener } from '../../files/openers.ts'
     4:	export {
     5|	  createUTF8Stream,
     6|	  streamFromString,
     7|	  streamFromUint8Array,
     8|	  UnicodeDecodeError,
     9|	} from '../../files/streams.ts'
    13:	export { readFileTree } from '../../files/deno.ts'
    15:	export { BIDSFileDeno } from '../../files/deno.ts'

repos/bids-validator/src/api/filetree/mod.ts
     1:	export { FileTree } from '../../types/filetree.ts'
     2:	export { filesToTree, loadBidsIgnore, subtree } from '../../files/filetree.ts'
     3:	export { FileIgnoreRules, readBidsIgnore } from '../../files/ignore.ts'

repos/bids-validator/src/api/issues/mod.ts
     1:	export { DatasetIssues, UnknownIssueCodeError } from '../../issues/datasetIssues.ts'
     2:	export { filterIssue } from '../../types/issues.ts'

repos/bids-validator/src/api/main/mod.ts
     9:	export { validate } from '../../validators/bids.ts'
    11:	export { getVersion } from '../../version.ts'
    15:	export { fileListToTree } from '../../files/browser.ts'
    17:	export { main } from '../../main.ts'

repos/bids-validator/src/api/options/mod.ts
    13:	export { validateCommand } from '../../setup/options.ts'
    15:	export { parseOptions } from '../../setup/options.ts'

repos/bids-validator/src/api/output/mod.ts
     1:	export { consoleFormat, resultToJSONStr } from '../../utils/output.ts'

repos/bids-validator/src/api/validate/mod.ts
     1:	export { validate } from '../../validators/bids.ts'
     2:	export { detectErrors } from '../../summary/summary.ts'
     3:	export { getVersion } from '../../version.ts'
```

</details>

All existing exports are preserved for backwards compatibility, but have been marked deprecated. I don't know if any tooling makes those deprecations actionable, but we'll keep them around for a major version.