### PR TITLE
fix: Compute opaque directories from actual DatasetType

### DIFF
--- a/changelog.d/20260421_095017_yarikoptic_bf_rawbids.md
+++ b/changelog.d/20260421_095017_yarikoptic_bf_rawbids.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- Compute opaque directories from the rules for the dataset's actual
+  `DatasetType` instead of always using `rules.directories.raw`.  This
+  lets study-type datasets correctly ignore the `rawbids/`
+  subdataset (added in
+  [bids-standard/bids-specification#2191](https://github.com/bids-standard/bids-specification/pull/2191))
+  and lets derivative-type datasets recognize derivative-only opaque
+  directories (e.g. `template`, `cohort`).  See
+  [#389](https://github.com/bids-standard/bids-validator/pull/389).

--- a/changelog.d/20260421_095017_yarikoptic_bf_rawbids.md
+++ b/changelog.d/20260421_095017_yarikoptic_bf_rawbids.md
@@ -3,8 +3,8 @@
 - Compute opaque directories from the rules for the dataset's actual
   `DatasetType` instead of always using `rules.directories.raw`.  This
   lets study-type datasets correctly ignore the `rawbids/`
-  subdataset (added in
-  [bids-standard/bids-specification#2191](https://github.com/bids-standard/bids-specification/pull/2191))
-  and lets derivative-type datasets recognize derivative-only opaque
-  directories (e.g. `template`, `cohort`).  See
-  [#389](https://github.com/bids-standard/bids-validator/pull/389).
+  subdataset (added in [bids-standard/bids-specification#2191][]).
+  Fixed in [#389][].
+
+[bids-standard/bids-specification#2191]: https://github.com/bids-standard/bids-specification/pull/2191
+[#389]: https://github.com/bids-standard/bids-validator/pull/389

--- a/src/schema/context.test.ts
+++ b/src/schema/context.test.ts
@@ -1,8 +1,8 @@
 import { assert, assertEquals, assertObjectMatch } from '@std/assert'
 import type { BIDSFile } from '../types/filetree.ts'
 import type { FileTree } from '../types/filetree.ts'
-import type { BIDSContextDataset } from './context.ts'
-import { BIDSContext } from './context.ts'
+import type { Schema } from '../types/schema.ts'
+import { BIDSContext, BIDSContextDataset } from './context.ts'
 import { dataFile, rootFileTree } from './fixtures.test.ts'
 
 /* Async helper to create a loaded BIDSContext */
@@ -36,6 +36,70 @@ Deno.test('test context LoadSidecar', async (t) => {
       context.dataset.issues.get({ code: 'SIDECAR_FIELD_OVERRIDE' }).length,
       2,
     )
+  })
+})
+
+Deno.test('BIDSContextDataset opaqueDirectories respects DatasetType', async (t) => {
+  const schema = {
+    objects: { extensions: {} },
+    rules: {
+      directories: {
+        raw: {
+          a: { opaque: true, name: 'a' },
+          b: { opaque: false, name: 'b' },
+        },
+        derivative: {
+          c: { opaque: true, name: 'c' },
+          d: { opaque: false, name: 'd' },
+        },
+      },
+    },
+  } as unknown as Schema
+
+  await t.step('default (raw) DatasetType populates raw opaque dirs', () => {
+    const ds = new BIDSContextDataset({ schema })
+    assertEquals(ds.opaqueDirectories.has('/a'), true)
+    assertEquals(ds.opaqueDirectories.has('/b'), false)
+    assertEquals(ds.opaqueDirectories.has('/c'), false)
+  })
+
+  await t.step('updating dataset_description switches opaque dirs', () => {
+    const ds = new BIDSContextDataset({ schema })
+    ds.dataset_description = { DatasetType: 'derivative' }
+    assertEquals(ds.opaqueDirectories.has('/c'), true)
+    assertEquals(ds.opaqueDirectories.has('/a'), false)
+    assertEquals(ds.opaqueDirectories.has('/d'), false)
+  })
+
+  await t.step('explicit derivative DatasetType on construction', () => {
+    const ds = new BIDSContextDataset({
+      schema,
+      dataset_description: { DatasetType: 'derivative' },
+    })
+    assertEquals(ds.opaqueDirectories.has('/c'), true)
+    assertEquals(ds.opaqueDirectories.has('/a'), false)
+    assertEquals(ds.opaqueDirectories.has('/d'), false)
+  })
+
+  await t.step('resetting to raw restores raw opaque dirs', () => {
+    const ds = new BIDSContextDataset({
+      schema,
+      dataset_description: { DatasetType: 'derivative' },
+    })
+    ds.dataset_description = { DatasetType: 'raw' }
+    assertEquals(ds.opaqueDirectories.has('/a'), true)
+    assertEquals(ds.opaqueDirectories.has('/b'), false)
+    assertEquals(ds.opaqueDirectories.has('/c'), false)
+  })
+
+  await t.step('GeneratedBy infers derivative when DatasetType missing', () => {
+    const ds = new BIDSContextDataset({
+      schema,
+      dataset_description: { GeneratedBy: [{ Name: 'foo' }] },
+    })
+    assertEquals(ds.dataset_description.DatasetType, 'derivative')
+    assertEquals(ds.opaqueDirectories.has('/c'), true)
+    assertEquals(ds.opaqueDirectories.has('/a'), false)
   })
 })
 

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -67,15 +67,20 @@ export class BIDSContextDataset implements Dataset {
           ?.filter((ext) => ext.endsWith('/'))
         : [],
     )
-    this.opaqueDirectories = new Set<string>(
-      args.schema
-        ? Object.values(this.schema.rules.directories.raw)
-          ?.filter((rule) => rule?.opaque && 'name' in rule)
-          ?.map((dir) => `/${dir.name}`)
-        : [],
-    )
+    this.opaqueDirectories = new Set<string>()
+    this.#refreshOpaqueDirectories()
     // @ts-expect-error Subjects type does not include null, but null is used as a sentinel for "not yet loaded"
     this.subjects = args.subjects || null
+  }
+
+  #refreshOpaqueDirectories(): void {
+    if (!this.schema?.rules?.directories) return
+    const datasetType = (this.dataset_description.DatasetType ?? 'raw') as string
+    this.opaqueDirectories = new Set<string>(
+      Object.values(this.schema.rules.directories[datasetType] ?? {})
+        ?.filter((rule) => rule?.opaque && 'name' in rule)
+        ?.map((dir) => `/${dir.name}`),
+    )
   }
 
   get dataset_description(): Record<string, unknown> {
@@ -89,6 +94,7 @@ export class BIDSContextDataset implements Dataset {
         ? 'derivative'
         : 'raw'
     }
+    this.#refreshOpaqueDirectories()
   }
 
   isPseudoFile(file: FileTree): boolean {

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -84,11 +84,9 @@ export class BIDSContextDataset implements Dataset {
     }
     const datasetType = this.dataset_description.DatasetType as string
     this.opaqueDirectories = new Set<string>(
-      this.schema?.rules?.directories
-        ? Object.values(this.schema.rules.directories[datasetType] ?? {})
-          ?.filter((rule) => rule?.opaque && 'name' in rule)
-          ?.map((dir) => `/${dir.name}`)
-        : [],
+      Object.values(this.schema?.rules?.directories[datasetType] ?? {})
+        .filter((rule) => rule.opaque)
+        .map((dir) => `/${dir.name}`),
     )
   }
 

--- a/src/schema/context.ts
+++ b/src/schema/context.ts
@@ -41,7 +41,7 @@ export class BIDSContextDataset implements Dataset {
   options?: ValidatorOptions
   schema: Schema
   pseudofileExtensions: Set<string>
-  opaqueDirectories: Set<string>
+  opaqueDirectories!: Set<string>
 
   // Opaque object for HED validator
   hedSchemas: HedSchemas | undefined | null = undefined
@@ -67,20 +67,8 @@ export class BIDSContextDataset implements Dataset {
           ?.filter((ext) => ext.endsWith('/'))
         : [],
     )
-    this.opaqueDirectories = new Set<string>()
-    this.#refreshOpaqueDirectories()
     // @ts-expect-error Subjects type does not include null, but null is used as a sentinel for "not yet loaded"
     this.subjects = args.subjects || null
-  }
-
-  #refreshOpaqueDirectories(): void {
-    if (!this.schema?.rules?.directories) return
-    const datasetType = (this.dataset_description.DatasetType ?? 'raw') as string
-    this.opaqueDirectories = new Set<string>(
-      Object.values(this.schema.rules.directories[datasetType] ?? {})
-        ?.filter((rule) => rule?.opaque && 'name' in rule)
-        ?.map((dir) => `/${dir.name}`),
-    )
   }
 
   get dataset_description(): Record<string, unknown> {
@@ -94,7 +82,14 @@ export class BIDSContextDataset implements Dataset {
         ? 'derivative'
         : 'raw'
     }
-    this.#refreshOpaqueDirectories()
+    const datasetType = this.dataset_description.DatasetType as string
+    this.opaqueDirectories = new Set<string>(
+      this.schema?.rules?.directories
+        ? Object.values(this.schema.rules.directories[datasetType] ?? {})
+          ?.filter((rule) => rule?.opaque && 'name' in rule)
+          ?.map((dir) => `/${dir.name}`)
+        : [],
+    )
   }
 
   isPseudoFile(file: FileTree): boolean {

--- a/src/validators/bids.ts
+++ b/src/validators/bids.ts
@@ -47,7 +47,7 @@ const perDSChecks: DSCheckFunction[] = [
  * `derivatives/` are detected via their own `dataset_description.json`;
  * when `options.recursive` is set, BIDS-conformant derivatives are
  * validated and their results attached to `derivativesSummary` on the
- * returned object. Non-BIDS derivatives and the `sourcedata`/`code`
+ * returned object. Non-BIDS derivatives and the `sourcedata`, `code`
  * directories are ignored.
  *
  * `validate` does not throw on validation failures — it records them as


### PR DESCRIPTION
Apparently

- https://github.com/bids-standard/bids-specification/pull/2191 (attn @nikhil153 @julia-pfarr @effigies )

was merged without testing effect on the validator. That lead to the validation of my

- https://github.com/bids-standard/bids-examples/pull/451

where I moved to use such `rawbids/`, to fail!    Took a few rounds with claude to figure out the underlying cause and address it (below from claude):

`BIDSContextDataset.opaqueDirectories` was hardcoded to `rules.directories.raw`, regardless of the dataset's `DatasetType`. This had two consequences:

- Derivative datasets did not recognize derivative-only opaque directories (e.g. `template`, `cohort`).
- Study datasets did not recognize study-only opaque directories (e.g. `rawbids/` added in bids-standard/bids-specification#2191), so the walker descended into them and raised `NOT_INCLUDED` on their contents.

Switch to `rules.directories[DatasetType]` so each dataset uses the rules for its own type.  `DatasetType` is only populated after the constructor runs (the caller assigns it from the loaded `dataset_description.json` afterward), so move the computation into a helper that is invoked from both the constructor and the `dataset_description` setter, keeping the set in sync.

PS there is also a tiny doc fix I could not go by since `sourcedata/code` is misleading !