### PR TITLE
feat(web): Allow users to pass custom schema to web validator

### DIFF
--- a/changelog.d/20260429_093638_markiewicz_web_custom_schema.md
+++ b/changelog.d/20260429_093638_markiewicz_web_custom_schema.md
@@ -1,0 +1,3 @@
+### Added
+
+- Allow custom schemas to be uploaded or passed by URL to the web validator.

--- a/deno.lock
+++ b/deno.lock
@@ -6,6 +6,8 @@
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
+    "jsr:@deno/esbuild-plugin@1.1.5": "1.1.5",
+    "jsr:@deno/loader@~0.3.3": "0.3.14",
     "jsr:@effigies/cliffy-command@1.0.0-dev.8": "1.0.0-dev.8",
     "jsr:@effigies/cliffy-table@1.0.0-dev.5": "1.0.0-dev.5",
     "jsr:@effigies/cliffy-table@^1.0.0-dev.5": "1.0.0-dev.5",
@@ -26,6 +28,7 @@
     "jsr:@std/io@~0.225.2": "0.225.3",
     "jsr:@std/io@~0.225.3": "0.225.3",
     "jsr:@std/log@~0.224.14": "0.224.14",
+    "jsr:@std/path@^1.1.1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/streams@^1.0.14": "1.0.14",
     "jsr:@std/streams@^1.0.17": "1.0.17",
@@ -65,6 +68,16 @@
       "dependencies": [
         "jsr:@std/fmt@~1.0.2"
       ]
+    },
+    "@deno/esbuild-plugin@1.1.5": {
+      "integrity": "c9cde95990b97802a0da6c73c26ab4a48f30d286818845e365dddcd8297abd7d",
+      "dependencies": [
+        "jsr:@deno/loader",
+        "jsr:@std/path@^1.1.1"
+      ]
+    },
+    "@deno/loader@0.3.14": {
+      "integrity": "97bc63a6cc2d27a60bcdc953f588c5213331d866d44212eebb24cebfb9b011ca"
     },
     "@effigies/cliffy-command@1.0.0-dev.8": {
       "integrity": "d6489c66bf7f603225a426b26b62eaee32bf6da04b69056bcb015a1f17190087",
@@ -108,7 +121,7 @@
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
         "jsr:@std/internal",
-        "jsr:@std/path"
+        "jsr:@std/path@^1.1.4"
       ]
     },
     "@std/internal@1.0.12": {
@@ -147,7 +160,7 @@
         "jsr:@std/data-structures",
         "jsr:@std/fs@^1.0.22",
         "jsr:@std/internal",
-        "jsr:@std/path"
+        "jsr:@std/path@^1.1.4"
       ]
     },
     "@std/text@1.0.17": {

--- a/web/README.md
+++ b/web/README.md
@@ -30,3 +30,19 @@ Currently there's a "papercut" for Deno users:
 
 - peer dependencies need to be referenced in `vite.config.js` - in this example
   it is `react` and `react-dom` packages that need to be referenced
+
+## Custom schemas
+
+The web app exposes an "Advanced options" panel beside the dataset selector.
+Use it to validate against a non-default schema:
+
+- **Schema version or URL** — accepts the same values as the CLI's `-s` flag:
+  a version tag (`stable`, `latest`, `v1.10.0`), or an `https://` URL pointing
+  at a `schema.json`.
+- **Use local schema file** — pick a local `schema.json` to validate against.
+  Mirrors the CLI's `file:///` URL support. The file takes precedence over the
+  text field.
+
+Leave both empty to use the schema bundled with the validator. Schema-load
+failures appear inline so you can fix the input and retry without re-selecting
+files.

--- a/web/deno.json
+++ b/web/deno.json
@@ -1,4 +1,7 @@
 {
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1.0.19"
+  },
   "tasks": {
     "dev": "../build.ts && deno run -A --node-modules-dir npm:vite",
     "build": "../build.ts && deno run -A --node-modules-dir npm:vite build",

--- a/web/deno.lock
+++ b/web/deno.lock
@@ -1,14 +1,27 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.13",
     "npm:@vitejs/plugin-react@^4.2.1": "4.3.4_vite@5.4.18_@babel+core@7.26.10",
     "npm:react-dom@^18.2.0": "18.3.1_react@18.3.1",
     "npm:react-markdown@^10.1.0": "10.1.0_@types+react@19.2.13_react@18.3.1",
     "npm:react@^18.2.0": "18.3.1",
     "npm:vite-plugin-https-imports@0.1.0": "0.1.0",
     "npm:vite-plugin-node-polyfills@0.22.0": "0.22.0_vite@5.4.18",
-    "npm:vite@*": "6.2.6",
+    "npm:vite@*": "5.4.18",
     "npm:vite@^5.0.10": "5.4.18"
+  },
+  "jsr": {
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.13": {
+      "integrity": "2f9546691d4ac2d32859c82dff284aaeac980ddeca38430d07941e7e288725c0"
+    }
   },
   "npm": {
     "@ampproject/remapping@2.3.0": {
@@ -157,18 +170,8 @@
       "os": ["aix"],
       "cpu": ["ppc64"]
     },
-    "@esbuild/aix-ppc64@0.25.2": {
-      "integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
-      "os": ["aix"],
-      "cpu": ["ppc64"]
-    },
     "@esbuild/android-arm64@0.21.5": {
       "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "os": ["android"],
-      "cpu": ["arm64"]
-    },
-    "@esbuild/android-arm64@0.25.2": {
-      "integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
       "os": ["android"],
       "cpu": ["arm64"]
     },
@@ -177,18 +180,8 @@
       "os": ["android"],
       "cpu": ["arm"]
     },
-    "@esbuild/android-arm@0.25.2": {
-      "integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
-      "os": ["android"],
-      "cpu": ["arm"]
-    },
     "@esbuild/android-x64@0.21.5": {
       "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "os": ["android"],
-      "cpu": ["x64"]
-    },
-    "@esbuild/android-x64@0.25.2": {
-      "integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
       "os": ["android"],
       "cpu": ["x64"]
     },
@@ -197,18 +190,8 @@
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@esbuild/darwin-arm64@0.25.2": {
-      "integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
-      "os": ["darwin"],
-      "cpu": ["arm64"]
-    },
     "@esbuild/darwin-x64@0.21.5": {
       "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "os": ["darwin"],
-      "cpu": ["x64"]
-    },
-    "@esbuild/darwin-x64@0.25.2": {
-      "integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
@@ -217,18 +200,8 @@
       "os": ["freebsd"],
       "cpu": ["arm64"]
     },
-    "@esbuild/freebsd-arm64@0.25.2": {
-      "integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
-      "os": ["freebsd"],
-      "cpu": ["arm64"]
-    },
     "@esbuild/freebsd-x64@0.21.5": {
       "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "os": ["freebsd"],
-      "cpu": ["x64"]
-    },
-    "@esbuild/freebsd-x64@0.25.2": {
-      "integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
       "os": ["freebsd"],
       "cpu": ["x64"]
     },
@@ -237,18 +210,8 @@
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@esbuild/linux-arm64@0.25.2": {
-      "integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
-      "os": ["linux"],
-      "cpu": ["arm64"]
-    },
     "@esbuild/linux-arm@0.21.5": {
       "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "os": ["linux"],
-      "cpu": ["arm"]
-    },
-    "@esbuild/linux-arm@0.25.2": {
-      "integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
       "os": ["linux"],
       "cpu": ["arm"]
     },
@@ -257,18 +220,8 @@
       "os": ["linux"],
       "cpu": ["ia32"]
     },
-    "@esbuild/linux-ia32@0.25.2": {
-      "integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
-      "os": ["linux"],
-      "cpu": ["ia32"]
-    },
     "@esbuild/linux-loong64@0.21.5": {
       "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "os": ["linux"],
-      "cpu": ["loong64"]
-    },
-    "@esbuild/linux-loong64@0.25.2": {
-      "integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
       "os": ["linux"],
       "cpu": ["loong64"]
     },
@@ -277,18 +230,8 @@
       "os": ["linux"],
       "cpu": ["mips64el"]
     },
-    "@esbuild/linux-mips64el@0.25.2": {
-      "integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
-      "os": ["linux"],
-      "cpu": ["mips64el"]
-    },
     "@esbuild/linux-ppc64@0.21.5": {
       "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "os": ["linux"],
-      "cpu": ["ppc64"]
-    },
-    "@esbuild/linux-ppc64@0.25.2": {
-      "integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
       "os": ["linux"],
       "cpu": ["ppc64"]
     },
@@ -297,18 +240,8 @@
       "os": ["linux"],
       "cpu": ["riscv64"]
     },
-    "@esbuild/linux-riscv64@0.25.2": {
-      "integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
-      "os": ["linux"],
-      "cpu": ["riscv64"]
-    },
     "@esbuild/linux-s390x@0.21.5": {
       "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "os": ["linux"],
-      "cpu": ["s390x"]
-    },
-    "@esbuild/linux-s390x@0.25.2": {
-      "integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
       "os": ["linux"],
       "cpu": ["s390x"]
     },
@@ -317,38 +250,13 @@
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@esbuild/linux-x64@0.25.2": {
-      "integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
-      "os": ["linux"],
-      "cpu": ["x64"]
-    },
-    "@esbuild/netbsd-arm64@0.25.2": {
-      "integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
-      "os": ["netbsd"],
-      "cpu": ["arm64"]
-    },
     "@esbuild/netbsd-x64@0.21.5": {
       "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "os": ["netbsd"],
       "cpu": ["x64"]
     },
-    "@esbuild/netbsd-x64@0.25.2": {
-      "integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
-      "os": ["netbsd"],
-      "cpu": ["x64"]
-    },
-    "@esbuild/openbsd-arm64@0.25.2": {
-      "integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
-      "os": ["openbsd"],
-      "cpu": ["arm64"]
-    },
     "@esbuild/openbsd-x64@0.21.5": {
       "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "os": ["openbsd"],
-      "cpu": ["x64"]
-    },
-    "@esbuild/openbsd-x64@0.25.2": {
-      "integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
       "os": ["openbsd"],
       "cpu": ["x64"]
     },
@@ -357,18 +265,8 @@
       "os": ["sunos"],
       "cpu": ["x64"]
     },
-    "@esbuild/sunos-x64@0.25.2": {
-      "integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
-      "os": ["sunos"],
-      "cpu": ["x64"]
-    },
     "@esbuild/win32-arm64@0.21.5": {
       "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "os": ["win32"],
-      "cpu": ["arm64"]
-    },
-    "@esbuild/win32-arm64@0.25.2": {
-      "integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
@@ -377,18 +275,8 @@
       "os": ["win32"],
       "cpu": ["ia32"]
     },
-    "@esbuild/win32-ia32@0.25.2": {
-      "integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
-      "os": ["win32"],
-      "cpu": ["ia32"]
-    },
     "@esbuild/win32-x64@0.21.5": {
       "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "os": ["win32"],
-      "cpu": ["x64"]
-    },
-    "@esbuild/win32-x64@0.25.2": {
-      "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -614,7 +502,7 @@
         "@babel/plugin-transform-react-jsx-source",
         "@types/babel__core",
         "react-refresh",
-        "vite@5.4.18"
+        "vite"
       ]
     },
     "ansi-regex@6.1.0": {
@@ -1026,61 +914,29 @@
     "esbuild@0.21.5": {
       "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "optionalDependencies": [
-        "@esbuild/aix-ppc64@0.21.5",
-        "@esbuild/android-arm@0.21.5",
-        "@esbuild/android-arm64@0.21.5",
-        "@esbuild/android-x64@0.21.5",
-        "@esbuild/darwin-arm64@0.21.5",
-        "@esbuild/darwin-x64@0.21.5",
-        "@esbuild/freebsd-arm64@0.21.5",
-        "@esbuild/freebsd-x64@0.21.5",
-        "@esbuild/linux-arm@0.21.5",
-        "@esbuild/linux-arm64@0.21.5",
-        "@esbuild/linux-ia32@0.21.5",
-        "@esbuild/linux-loong64@0.21.5",
-        "@esbuild/linux-mips64el@0.21.5",
-        "@esbuild/linux-ppc64@0.21.5",
-        "@esbuild/linux-riscv64@0.21.5",
-        "@esbuild/linux-s390x@0.21.5",
-        "@esbuild/linux-x64@0.21.5",
-        "@esbuild/netbsd-x64@0.21.5",
-        "@esbuild/openbsd-x64@0.21.5",
-        "@esbuild/sunos-x64@0.21.5",
-        "@esbuild/win32-arm64@0.21.5",
-        "@esbuild/win32-ia32@0.21.5",
-        "@esbuild/win32-x64@0.21.5"
-      ],
-      "scripts": true,
-      "bin": true
-    },
-    "esbuild@0.25.2": {
-      "integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
-      "optionalDependencies": [
-        "@esbuild/aix-ppc64@0.25.2",
-        "@esbuild/android-arm@0.25.2",
-        "@esbuild/android-arm64@0.25.2",
-        "@esbuild/android-x64@0.25.2",
-        "@esbuild/darwin-arm64@0.25.2",
-        "@esbuild/darwin-x64@0.25.2",
-        "@esbuild/freebsd-arm64@0.25.2",
-        "@esbuild/freebsd-x64@0.25.2",
-        "@esbuild/linux-arm@0.25.2",
-        "@esbuild/linux-arm64@0.25.2",
-        "@esbuild/linux-ia32@0.25.2",
-        "@esbuild/linux-loong64@0.25.2",
-        "@esbuild/linux-mips64el@0.25.2",
-        "@esbuild/linux-ppc64@0.25.2",
-        "@esbuild/linux-riscv64@0.25.2",
-        "@esbuild/linux-s390x@0.25.2",
-        "@esbuild/linux-x64@0.25.2",
-        "@esbuild/netbsd-arm64",
-        "@esbuild/netbsd-x64@0.25.2",
-        "@esbuild/openbsd-arm64",
-        "@esbuild/openbsd-x64@0.25.2",
-        "@esbuild/sunos-x64@0.25.2",
-        "@esbuild/win32-arm64@0.25.2",
-        "@esbuild/win32-ia32@0.25.2",
-        "@esbuild/win32-x64@0.25.2"
+        "@esbuild/aix-ppc64",
+        "@esbuild/android-arm",
+        "@esbuild/android-arm64",
+        "@esbuild/android-x64",
+        "@esbuild/darwin-arm64",
+        "@esbuild/darwin-x64",
+        "@esbuild/freebsd-arm64",
+        "@esbuild/freebsd-x64",
+        "@esbuild/linux-arm",
+        "@esbuild/linux-arm64",
+        "@esbuild/linux-ia32",
+        "@esbuild/linux-loong64",
+        "@esbuild/linux-mips64el",
+        "@esbuild/linux-ppc64",
+        "@esbuild/linux-riscv64",
+        "@esbuild/linux-s390x",
+        "@esbuild/linux-x64",
+        "@esbuild/netbsd-x64",
+        "@esbuild/openbsd-x64",
+        "@esbuild/sunos-x64",
+        "@esbuild/win32-arm64",
+        "@esbuild/win32-ia32",
+        "@esbuild/win32-x64"
       ],
       "scripts": true,
       "bin": true
@@ -1728,7 +1584,7 @@
         "readable-stream@3.6.2",
         "stream-browserify",
         "stream-http",
-        "string_decoder@1.3.0",
+        "string_decoder",
         "timers-browserify",
         "tty-browserify",
         "url",
@@ -1960,7 +1816,7 @@
         "isarray",
         "process-nextick-args",
         "safe-buffer@5.1.2",
-        "string_decoder@1.1.1",
+        "string_decoder",
         "util-deprecate"
       ]
     },
@@ -1968,7 +1824,7 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": [
         "inherits",
-        "string_decoder@1.3.0",
+        "string_decoder",
         "util-deprecate"
       ]
     },
@@ -2171,12 +2027,6 @@
         "safe-buffer@5.1.2"
       ]
     },
-    "string_decoder@1.3.0": {
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": [
-        "safe-buffer@5.2.1"
-      ]
-    },
     "stringify-entities@4.0.4": {
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
       "dependencies": [
@@ -2323,25 +2173,13 @@
       "dependencies": [
         "@rollup/plugin-inject",
         "node-stdlib-browser",
-        "vite@5.4.18"
+        "vite"
       ]
     },
     "vite@5.4.18": {
       "integrity": "sha512-1oDcnEp3lVyHCuQ2YFelM4Alm2o91xNoMncRm1U7S+JdYfYOvbiGZ3/CxGttrOu2M/KcGz7cRC2DoNUA6urmMA==",
       "dependencies": [
-        "esbuild@0.21.5",
-        "postcss",
-        "rollup"
-      ],
-      "optionalDependencies": [
-        "fsevents"
-      ],
-      "bin": true
-    },
-    "vite@6.2.6": {
-      "integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
-      "dependencies": [
-        "esbuild@0.25.2",
+        "esbuild",
         "postcss",
         "rollup"
       ],
@@ -2377,5 +2215,10 @@
     "zwitch@2.0.4": {
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@^1.0.19"
+    ]
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,12 @@ import { fileListToTree, getVersion, validate } from "../dist/validator/web.js";
 import type { ValidationResult } from "../../src/types/validation-result.ts";
 import { Collapse } from "./Collapse.tsx";
 import { Summary } from "./Summary.tsx";
+import { SchemaPicker } from "./SchemaPicker.tsx";
+import {
+  computeEffectiveSchema,
+  isSchemaLoadError,
+  type SchemaFile,
+} from "./schemaOption.ts";
 
 function formatMessage(text) {
   if (!text) return "";
@@ -74,19 +80,54 @@ function Issue({ data }) {
 
 function App() {
   const [validation, setValidation] = useState<ValidationResult>();
+  const [schemaText, setSchemaText] = useState<string>("");
+  const [schemaFile, setSchemaFile] = useState<
+    (SchemaFile & { name: string }) | null
+  >(null);
+  const [schemaError, setSchemaError] = useState<string | undefined>();
 
   async function validateDir() {
-    const dirHandle = await directoryOpen({
-      recursive: true,
-    });
+    const dirHandle = await directoryOpen({ recursive: true });
     const fileTree = await fileListToTree(dirHandle);
-    setValidation(await validate(fileTree, {}));
+    const schema = computeEffectiveSchema(schemaText, schemaFile);
+    try {
+      setValidation(await validate(fileTree, { schema }));
+      setSchemaError(undefined);
+    } catch (err) {
+      if (isSchemaLoadError(err)) {
+        setSchemaError(
+          err instanceof Error ? err.message : String(err),
+        );
+        setValidation(undefined);
+      } else {
+        setSchemaError(
+          `Validation failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+        setValidation(undefined);
+      }
+    }
   }
 
   const [version, setVersion] = useState<string>();
   getVersion().then((v) => {
     setVersion(v);
   });
+
+  const advanced = (
+    <>
+      <Collapse label="Advanced options">
+        <SchemaPicker
+          text={schemaText}
+          onTextChange={setSchemaText}
+          file={schemaFile}
+          onFileChange={setSchemaFile}
+        />
+      </Collapse>
+      {schemaError && <div className="error schema-error">{schemaError}</div>}
+    </>
+  );
 
   let validatorOutput;
 
@@ -129,6 +170,7 @@ function App() {
     validatorOutput = (
       <>
         <button onClick={validateDir}>Reselect Files</button>
+        {advanced}
         <div>
           <ul className="issues-list">
             {errorList}
@@ -161,6 +203,7 @@ function App() {
           to validate.
         </h2>
         <button onClick={validateDir}>Select Dataset Files</button>
+        {advanced}
       </>
     );
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import "./App.css";
 import { directoryOpen } from "https://esm.sh/browser-fs-access@0.35.0";
 import confetti from "https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.module.mjs";
@@ -111,9 +111,8 @@ function App() {
   }
 
   const [version, setVersion] = useState<string>();
-  getVersion().then((v) => {
-    setVersion(v);
-  });
+  // useEffect avoids rerunning getVersion on every render
+  useEffect(() => getVersion().then(setVersion), []);
 
   const advanced = (
     <>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,25 +1,25 @@
-import React, { useState } from "react"
-import "./App.css"
-import { directoryOpen } from "https://esm.sh/browser-fs-access@0.35.0"
-import confetti from 'https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.module.mjs';
-import Markdown from "react-markdown"
-import { fileListToTree, validate, getVersion } from "../dist/validator/web.js"
-import type { ValidationResult } from "../../src/types/validation-result.ts"
-import { Collapse } from "./Collapse.tsx"
-import { Summary } from "./Summary.tsx"
+import React, { useState } from "react";
+import "./App.css";
+import { directoryOpen } from "https://esm.sh/browser-fs-access@0.35.0";
+import confetti from "https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.module.mjs";
+import Markdown from "react-markdown";
+import { fileListToTree, getVersion, validate } from "../dist/validator/web.js";
+import type { ValidationResult } from "../../src/types/validation-result.ts";
+import { Collapse } from "./Collapse.tsx";
+import { Summary } from "./Summary.tsx";
 
 function formatMessage(text) {
-  if (!text) return ""
+  if (!text) return "";
   return text.replaceAll(
-    'SPEC_ROOT/',
-    'https://bids-specification.readthedocs.io/en/stable/',
-  )
+    "SPEC_ROOT/",
+    "https://bids-specification.readthedocs.io/en/stable/",
+  );
 }
 
 function Files({ issues }) {
   const unique = new Map(issues.map(({ location, issueMessage }) => {
-    return [`${location}${issueMessage ?? ''}`, { location, issueMessage }]
-  }))
+    return [`${location}${issueMessage ?? ""}`, { location, issueMessage }];
+  }));
   return (
     <ul>
       {[...unique.values()].map(({ location, issueMessage }) => {
@@ -28,30 +28,31 @@ function Files({ issues }) {
             {location}
             {issueMessage && (
               <>
-                {' ('}
+                {" ("}
                 <span style={{ display: "inline-block", verticalAlign: "top" }}>
-                  <Markdown components={{ p: 'span' }}>
+                  <Markdown components={{ p: "span" }}>
                     {formatMessage(issueMessage)}
                   </Markdown>
                 </span>
-                {')'}
+                {")"}
               </>
             )}
           </li>
-        )
+        );
       })}
     </ul>
-  )
+  );
 }
 
 function Issue({ data }) {
-  const { code, severity } = data.issues[0]
-  const ret = []
-  for (const [subCode, subIssues] of data.groupBy('subCode')) {
+  const { code, severity } = data.issues[0];
+  const ret = [];
+  for (const [subCode, subIssues] of data.groupBy("subCode")) {
     if (subIssues.size === 0) {
-      continue
+      continue;
     }
-    const label = `${severity}: ${code}` + (subCode === 'None' ? '' : ` (${subCode})`)
+    const label = `${severity}: ${code}` +
+      (subCode === "None" ? "" : ` (${subCode})`);
     ret.push(
       <div className={severity}>
         <Collapse label={label}>
@@ -65,56 +66,64 @@ function Issue({ data }) {
             </a>
           </p>
         </Collapse>
-      </div>
-    )
+      </div>,
+    );
   }
-  return ret
+  return ret;
 }
 
 function App() {
-  const [validation, setValidation] = useState<ValidationResult>()
+  const [validation, setValidation] = useState<ValidationResult>();
 
   async function validateDir() {
     const dirHandle = await directoryOpen({
       recursive: true,
-    })
-    const fileTree = await fileListToTree(dirHandle)
-    setValidation(await validate(fileTree, {}))
+    });
+    const fileTree = await fileListToTree(dirHandle);
+    setValidation(await validate(fileTree, {}));
   }
 
-  const [version, setVersion] = useState<string>()
-  getVersion().then((v) => { setVersion(v) })
+  const [version, setVersion] = useState<string>();
+  getVersion().then((v) => {
+    setVersion(v);
+  });
 
-  let validatorOutput
+  let validatorOutput;
 
   if (validation) {
-    const errorList = []
-    const warningList = []
-    let success = ""
-    for (const [code, issues] of validation.issues.filter({ severity: 'error' }).groupBy('code')) {
-      if (code === 'None') {
-        continue
+    const errorList = [];
+    const warningList = [];
+    let success = "";
+    for (
+      const [code, issues] of validation.issues.filter({ severity: "error" })
+        .groupBy("code")
+    ) {
+      if (code === "None") {
+        continue;
       }
-      errorList.push(...Issue({ data: issues }))
+      errorList.push(...Issue({ data: issues }));
     }
-    for (const [code, issues] of validation.issues.filter({ severity: 'warning' }).groupBy('code')) {
-      if (code === 'None') {
-        continue
+    for (
+      const [code, issues] of validation.issues.filter({ severity: "warning" })
+        .groupBy("code")
+    ) {
+      if (code === "None") {
+        continue;
       }
-      warningList.push(...Issue({ data: issues }))
+      warningList.push(...Issue({ data: issues }));
     }
     if (errorList.length === 0 && warningList.length === 0) {
       success = (
-      <div className="success">
-        <Collapse label="No Issues Detected!">
-          <div>Thanks for Everything. I Have No Complaints Whatsoever.</div>
-        </Collapse>
-      </div>
-      )
+        <div className="success">
+          <Collapse label="No Issues Detected!">
+            <div>Thanks for Everything. I Have No Complaints Whatsoever.</div>
+          </Collapse>
+        </div>
+      );
       confetti({
         particleCount: 500,
         spread: 180,
-        ticks: 400
+        ticks: 400,
       });
     }
     validatorOutput = (
@@ -128,7 +137,9 @@ function App() {
           </ul>
           <Summary data={validation.summary} />
           <a
-            href={`data:application/json;charset=utf-8,${encodeURIComponent(JSON.stringify(validation))}`}
+            href={`data:application/json;charset=utf-8,${
+              encodeURIComponent(JSON.stringify(validation))
+            }`}
             target="_blank"
             download="bids-validator-output.json"
           >
@@ -136,11 +147,10 @@ function App() {
           </a>
         </div>
       </>
-    )
+    );
     if (errorList.length === 0) {
     }
   } else {
-
     validatorOutput = (
       <>
         <h2>
@@ -152,20 +162,25 @@ function App() {
         </h2>
         <button onClick={validateDir}>Select Dataset Files</button>
       </>
-    )
+    );
   }
   return (
     <>
       <h1>BIDS Validator</h1>
       {validatorOutput}
-      <div><em>BIDS Validator version: {version}</em></div>
+      <div>
+        <em>BIDS Validator version: {version}</em>
+      </div>
       <div>
         Note: Selecting a dataset only performs validation. Files are never
         uploaded.
       </div>
-      <div>The legacy BIDS Validator is available <a href="https://bids-standard.github.io/legacy-validator/">here.</a></div>
+      <div>
+        The legacy BIDS Validator is available{" "}
+        <a href="https://bids-standard.github.io/legacy-validator/">here.</a>
+      </div>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/web/src/SchemaPicker.css
+++ b/web/src/SchemaPicker.css
@@ -1,0 +1,32 @@
+.schema-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.schema-picker-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.schema-picker-row > span {
+  min-width: 12rem;
+}
+
+.schema-picker-row input[type="text"] {
+  flex: 1;
+  min-width: 18rem;
+}
+
+.schema-picker-filename {
+  font-style: italic;
+}
+
+.schema-picker-hint {
+  margin: 0;
+  font-size: 0.9em;
+  opacity: 0.8;
+}

--- a/web/src/SchemaPicker.tsx
+++ b/web/src/SchemaPicker.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef } from "react";
+import "./SchemaPicker.css";
+import type { SchemaFile } from "./schemaOption.ts";
+
+interface Props {
+  text: string;
+  onTextChange: (value: string) => void;
+  file: (SchemaFile & { name: string }) | null;
+  onFileChange: (file: (SchemaFile & { name: string }) | null) => void;
+}
+
+export function SchemaPicker(
+  { text, onTextChange, file, onFileChange }: Props,
+) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const url = file?.blobUrl;
+    if (!url) return;
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [file?.blobUrl]);
+
+  function handleFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    onFileChange({ blobUrl: URL.createObjectURL(f), name: f.name });
+  }
+
+  function clearFile() {
+    onFileChange(null);
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  const fileSelected = file !== null;
+
+  return (
+    <div className="schema-picker">
+      <label className="schema-picker-row">
+        <span>Schema version or URL</span>
+        <input
+          type="text"
+          value={text}
+          disabled={fileSelected}
+          placeholder="stable, v1.10.0, or https://…/schema.json"
+          onChange={(e) => onTextChange(e.target.value)}
+        />
+      </label>
+      <div className="schema-picker-row">
+        <label>
+          <span>Use local schema file</span>
+          <input
+            ref={inputRef}
+            type="file"
+            accept=".json,application/json"
+            onChange={handleFileSelected}
+          />
+        </label>
+        {fileSelected && (
+          <>
+            <span className="schema-picker-filename">{file!.name}</span>
+            <button type="button" onClick={clearFile}>Clear file</button>
+          </>
+        )}
+      </div>
+      <p className="schema-picker-hint">
+        Leave empty to validate against the bundled schema.
+      </p>
+    </div>
+  );
+}

--- a/web/src/schemaOption.test.ts
+++ b/web/src/schemaOption.test.ts
@@ -1,0 +1,36 @@
+import { assertEquals } from "@std/assert";
+import { computeEffectiveSchema, isSchemaLoadError } from "./schemaOption.ts";
+
+Deno.test("computeEffectiveSchema: empty inputs -> undefined", () => {
+  assertEquals(computeEffectiveSchema("", null), undefined);
+  assertEquals(computeEffectiveSchema("   ", null), undefined);
+});
+
+Deno.test("computeEffectiveSchema: text only -> trimmed string", () => {
+  assertEquals(computeEffectiveSchema("stable", null), "stable");
+  assertEquals(computeEffectiveSchema("  v1.10.0  ", null), "v1.10.0");
+});
+
+Deno.test("computeEffectiveSchema: file wins over text", () => {
+  const blobUrl = "blob:fake";
+  assertEquals(
+    computeEffectiveSchema("stable", { blobUrl }),
+    "blob:fake",
+  );
+});
+
+Deno.test("computeEffectiveSchema: file only", () => {
+  assertEquals(
+    computeEffectiveSchema("", { blobUrl: "blob:abc" }),
+    "blob:abc",
+  );
+});
+
+Deno.test("isSchemaLoadError: matches loadSchema prefix", () => {
+  assertEquals(
+    isSchemaLoadError(new Error("Failed to load schema from foo: x")),
+    true,
+  );
+  assertEquals(isSchemaLoadError(new Error("something else")), false);
+  assertEquals(isSchemaLoadError("not an error"), false);
+});

--- a/web/src/schemaOption.ts
+++ b/web/src/schemaOption.ts
@@ -1,0 +1,17 @@
+export interface SchemaFile {
+  blobUrl: string;
+}
+
+export function computeEffectiveSchema(
+  text: string,
+  file: SchemaFile | null,
+): string | undefined {
+  if (file) return file.blobUrl;
+  const trimmed = text.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+export function isSchemaLoadError(err: unknown): boolean {
+  return err instanceof Error &&
+    err.message.startsWith("Failed to load schema");
+}


### PR DESCRIPTION
It turns out using custom schemas on Windows is painful (cc @melanieganz for links to the known problems). This is a quick hack to allow loading custom schemas in the web validator.

The error reporting is not well styled, but this gets the job done.