### PR TITLE
Don't generate sidecarkey required errors for derivative datasets fromm non derivative related sidecar rules.

### DIFF
--- a/changelog.d/20260504_150528_rosswilsonblair_derivative_metadata_requirements.md
+++ b/changelog.d/20260504_150528_rosswilsonblair_derivative_metadata_requirements.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- Derivative datasets no longer generate warnings or errors for sidecar keys that don't explicitly apply to derivative datasets.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -216,8 +216,7 @@ function evalJsonCheck(
        */
       if (
         context.dataset.dataset_description.DatasetType === 'derivative' &&
-        schemaPath.startsWith('rules.sidecars') &&
-        !schemaPath.startsWith('rules.sidecars.derivatives')
+        !rule.selectors.includes('dataset.dataset_description.DatasetType == "derivative"')
       ) {
         continue
       }

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -216,7 +216,7 @@ function evalJsonCheck(
        */
       if (
         context.dataset.dataset_description.DatasetType === 'derivative' &&
-        !rule.selectors.includes('dataset.dataset_description.DatasetType == "derivative"')
+        !rule.selectors?.includes('dataset.dataset_description.DatasetType == "derivative"')
       ) {
         continue
       }

--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -205,28 +205,43 @@ function evalJsonCheck(
 
     if (value === undefined) {
       const severity = getFieldSeverity(requirement, context)
-      if (severity && severity !== 'ignore') {
-        if (requirement.issue?.code && requirement.issue?.message) {
-          context.dataset.issues.add({
-            code: requirement.issue.code,
-            subCode: keyName,
-            location: context.path,
-            severity,
-            rule: schemaPath,
-            issueMessage,
-          }, requirement.issue.message)
-        } else {
-          const keyType = sidecarRule ? 'SIDECAR_KEY' : 'JSON_KEY'
-          const level = severity === 'error' ? 'REQUIRED' : 'RECOMMENDED'
-          context.dataset.issues.add({
-            code: `${keyType}_${level}`,
-            subCode: keyName,
-            location: context.path,
-            severity,
-            rule: schemaPath,
-            issueMessage,
-          })
-        }
+      if (severity && (severity === 'ignore')) {
+        continue
+      }
+
+      /*
+       * quoth derivatives introduction in the specification:
+       *
+       * "Unless specified otherwise, individual sidecar JSON files and all metadata fields within are OPTIONAL."
+       */
+      if (
+        context.dataset.dataset_description.DatasetType === 'derivative' &&
+        schemaPath.startsWith('rules.sidecars') &&
+        !schemaPath.startsWith('rules.sidecars.derivatives')
+      ) {
+        continue
+      }
+
+      if (requirement.issue?.code && requirement.issue?.message) {
+        context.dataset.issues.add({
+          code: requirement.issue.code,
+          subCode: keyName,
+          location: context.path,
+          severity,
+          rule: schemaPath,
+          issueMessage,
+        }, requirement.issue.message)
+      } else {
+        const keyType = sidecarRule ? 'SIDECAR_KEY' : 'JSON_KEY'
+        const level = severity === 'error' ? 'REQUIRED' : 'RECOMMENDED'
+        context.dataset.issues.add({
+          code: `${keyType}_${level}`,
+          subCode: keyName,
+          location: context.path,
+          severity,
+          rule: schemaPath,
+          issueMessage,
+        })
       }
 
       /* Regardless of if key is required/recommended/optional, we do no


### PR DESCRIPTION
This skips the question of `schema.rules.json` entries. There are currently no rules there that explicitly apply to derivatives. Are the rules in there metadata?

One issue is we are relying on derivatives sub directory in `schema.rules.sidecars` If rules ever get reorganized it will cause a regression.