### PR TITLE
chore: enable esbuild code splitting for hed-validator

### DIFF
--- a/.github/workflows/deno_tests.yml
+++ b/.github/workflows/deno_tests.yml
@@ -153,10 +153,8 @@ jobs:
           path: main
       - name: Commit to new branch
         run: |
-          mv main/bids-validator.js .
-          git add bids-validator.js
-          # Probably only runs once, but avoids accidents. Can be removed in a bit.
-          git rm --ignore-unmatch main.js
+          mv main/*-*.js .
+          git add *-*.js
           git commit -m "BLD: $VERSION [skip ci]" || true
         env:
           VERSION: ${{ needs.build.describe.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN deno run -A ./build.ts
 
 FROM ${BASE_IMAGE} AS min
 WORKDIR /src
-COPY --from=build /src/dist/validator/bids-validator.js .
+COPY --from=build /src/dist/validator/*-*.js .
 
 ENTRYPOINT ["deno", "-A", "/src/bids-validator.js"]

--- a/build.ts
+++ b/build.ts
@@ -44,6 +44,7 @@ const versionPlugin = {
 }
 
 const result = await esbuild.build({
+  splitting: true,
   format: 'esm',
   entryPoints: [MAIN_ENTRY, CLI_ENTRY],
   bundle: true,

--- a/changelog.d/20260506_141943_guttulacharansai_feat_esbuild_splitting.md
+++ b/changelog.d/20260506_141943_guttulacharansai_feat_esbuild_splitting.md
@@ -1,0 +1,6 @@
+### Infrastructure
+
+- Code-splitting was enabled in bundle configuration to make the validator more
+  friendly to load in the browser or include in downstream bundled applications.
+  The initial validator load transfers less than 400kB and
+  only loads an additional 1.2MB if HED validation is required.

--- a/web/vite.config.mts
+++ b/web/vite.config.mts
@@ -14,7 +14,7 @@ function workaroundAssetImportMetaUrlPluginBug() {
   return {
     name: "vite-workaround-import-glob",
     transform(src, id) {
-      if (id.includes('validator/web.js')) {
+      if (src.includes(', import.meta.url')) {
         return src.replace(", import.meta.url", "")
       } else {
         return null


### PR DESCRIPTION
Follow-up to my previous PR (#362) to enable actual code chunking in the build system, successfully resolving the bundle size issue originally discussed in #355.

Changes:

Updated build.ts to enable splitting: true and format: 'esm'.

Updated the vite.config.mts to check src.includes instead of id.includes to ensure the import.meta.url string replacement catches the newly split chunk safely.

Tested locally, and the build system successfully generates the isolated chunk (chunk-XXXX.js in /dist/validator and esm-XXXX.js in /web/dist/assets).

@effigies @nellh Let me know how this looks on your end!