### PR TITLE
parseStack: don't throw on header-less Error.stack formats

### DIFF
--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -29,4 +29,28 @@ Deno.test('logger', async (t) => {
       'loadHeader (file:///bids-validator/bids-validator/src/files/nifti.ts:18:12)',
     )
   })
+  await t.step('does not throw on WebKit-shaped Error.stack', () => {
+    // WebKit / JavaScriptCore (Safari, Tauri's WRY WebView, embedded JSC)
+    // emits a header-less, `function@file:line`-shaped stack that often
+    // has fewer than three frames. The original `lines[2].trim()` threw
+    // `TypeError: undefined is not an object` on the FIRST validator-
+    // internal logger access, regardless of log level, breaking
+    // validator use under any non-V8 runtime.
+    const webkitTwoFrame =
+      'get@file:///bids-validator/src/utils/logger.ts:30:32\nvalidate@file:///bids-validator/src/validators/bids.ts:110:18\n'
+    // Must not throw, and must return a defined-or-undefined value (the
+    // caller -- a template-literal interpolation -- handles both).
+    const result = parseStack(webkitTwoFrame)
+    if (result !== undefined && typeof result !== 'string') {
+      throw new Error(`parseStack returned non-string non-undefined: ${result}`)
+    }
+  })
+  await t.step('does not throw on an empty stack', () => {
+    // Defensive: some runtimes (e.g. when Error.stack is disabled or
+    // captureStackTrace returns "") emit empty strings.
+    const result = parseStack('')
+    if (result !== undefined && typeof result !== 'string') {
+      throw new Error(`parseStack returned non-string non-undefined: ${result}`)
+    }
+  })
 })

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -18,11 +18,31 @@ export function setupLogging(level: LevelName) {
   })
 }
 
-export function parseStack(stack: string) {
+export function parseStack(stack: string): string | undefined {
+  // V8's Error.stack format starts with an "Error" header line followed
+  // by frames, so the original caller of the throwing site sits at
+  // lines[2]. WebKit / JavaScriptCore (Safari, Tauri's WRY WebView, some
+  // embedded JSC contexts) emits a header-less, `function@file:line`-
+  // shaped stack that often has fewer than three frames; on those
+  // engines `lines[2]` is undefined and `lines[2].trim()` throws
+  // `TypeError: undefined is not an object`.
+  //
+  // Because `loggerProxyHandler.get` calls `parseStack` unconditionally
+  // on every logger method access -- before the log level check --
+  // this throw fires on the FIRST validator-internal logger touch in
+  // any non-V8 runtime, regardless of `--debug` level. That makes it
+  // impossible to run the validator under WebKit / JSC today.
+  //
+  // Fall back to lines[0] (and finally undefined) so non-V8 engines
+  // get a slightly-less-detailed debug location instead of a fatal
+  // throw. The caller's only consumer is a template-literal interpolation
+  // (`Logger invoked at "${callerLocation}"`), which handles undefined
+  // harmlessly.
   const lines = stack.split('\n')
-  const caller = lines[2].trim()
+  const caller = (lines[2] ?? lines[0])?.trim()
+  if (!caller) return undefined
   const token = caller.split('at ')
-  return token[1]
+  return token[1] ?? caller
 }
 
 const loggerProxyHandler = {


### PR DESCRIPTION
`parseStack` indexes `stack.split('\n')[2].trim()` to extract the original caller. V8's Error.stack format prepends an "Error" header line, so the original caller does land at `lines[2]` in V8-based runtimes (Deno, Node, Chrome). WebKit / JavaScriptCore — the JS engine in Safari and in WRY-based desktop wrappers like Tauri — emits a header-less `function@file:line`-shaped stack that often has fewer than three frames. `lines[2]` is undefined there, and the `.trim()` call throws `TypeError: undefined is not an object`.

This matters more than it looks: `loggerProxyHandler.get` calls `parseStack` *unconditionally* on every logger method access, *before* the log level check. So in any non-V8 runtime the validator throws on the first internal logger touch (which happens at the very top of `validate()`), regardless of `--debug` level. Today there's no way to run `@bids/validator` inside WebKit — e.g. browser tools layered on top of the validator, or Tauri-shelled BIDS browsers like [BIDSvue](https://github.com/neurolabusc/bidsui) — without patching this function out at install time.

### Repro (WebKit)

The two-frame stack below is representative of what Safari / JavaScriptCore emits at the first `logger.debug(…)` call inside `validate()`:

```
get@file:///.../src/utils/logger.ts:30:32
validate@file:///.../src/validators/bids.ts:110:18
```

`stack.split('\n')` produces `['get@…', 'validate@…', '']` — only three entries, the third empty. On the very first logger access (when there are only two frames) `lines[2]` is `undefined` and `.trim()` throws.

### Fix

Fall back from `lines[2]` to `lines[0]` (and finally `undefined`) so non-V8 engines get a less-detailed debug location instead of a fatal throw. The only consumer of the return value is a template-literal interpolation:

```ts
logger.debug(`Logger invoked at "${callerLocation}"`)
```

…which handles `undefined` harmlessly (renders `"undefined"`).

### Tests

Two new regression cases under the existing `Deno.test('logger')` suite:

- WebKit-shaped two-frame stack (no header, `function@file:line` lines).
- Empty-string stack (defensive against runtimes where `Error.stack` is disabled or `Error.captureStackTrace` returns `""`).

Both assert that `parseStack` returns either a `string` or `undefined` without throwing. The existing V8-stack tests still pass.

`deno test -A src/utils/logger.test.ts`, `deno fmt`, and `deno lint` all clean locally.

### Out of scope

This PR fixes only the throw. It doesn't redesign the logger's caller-location strategy — that's a separate question (`new Error()` capture is already a hack; structured logger context would be the cleaner long-term fix). It also doesn't touch any of the other Deno-flavoured JSR-interop patterns elsewhere in the codebase that make the validator hard to bundle for browser consumers (`import { default as X } from "cjs-pkg"`, `import "./foo.json" with { type: "json" }`); those are independent.