### PR TITLE
perf: share isomorphic-git cache and memoize git-annex ref across the dataset walk

### DIFF
--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -33,6 +33,21 @@ type ReadFileTreeOptions = {
   prune: FileIgnoreRules
   parent?: FileTree
   preferredRemote?: string
+  /**
+   * Per-dataset isomorphic-git cache, shared across the entire walk so that
+   * pack-file inflation is amortised across all annex pointers we encounter.
+   * One cache per gitdir.
+   */
+  gitCaches?: Map<string, object>
+}
+
+function getGitCache(caches: Map<string, object>, gitdir: string): object {
+  let cache = caches.get(gitdir)
+  if (cache === undefined) {
+    cache = {}
+    caches.set(gitdir, cache)
+  }
+  return cache
 }
 
 async function _readFileTree({
@@ -42,13 +57,13 @@ async function _readFileTree({
   prune,
   parent,
   preferredRemote,
+  gitCaches,
 }: ReadFileTreeOptions): Promise<FileTree> {
   await requestReadPermission()
   const name = basename(relativePath)
   const tree = new FileTree(relativePath, name, parent, ignore)
 
-  // Opaque cache for passing to git operations
-  const cache = {}
+  gitCaches ??= new Map()
 
   for await (const dirEntry of Deno.readDir(join(rootPath, relativePath))) {
     const thisPath = posix.join(relativePath, dirEntry.name)
@@ -69,6 +84,7 @@ async function _readFileTree({
       const annexParsed = parseAnnexKey(target)
       if (annexParsed !== null) {
         const gitdir = gitdirFromLink(fullPath, target)
+        const cache = getGitCache(gitCaches, gitdir)
         const opener = new AnnexedGitFileOpener(
           annexParsed.key,
           annexParsed.size,
@@ -109,6 +125,7 @@ async function _readFileTree({
         prune,
         parent: tree,
         preferredRemote,
+        gitCaches,
       })
       tree.directories.push(dirTree)
     }

--- a/src/files/repo.ts
+++ b/src/files/repo.ts
@@ -66,13 +66,37 @@ async function _createS3Client(options: S3ClientOptions): Promise<S3Client | Non
 
 const createS3Client = memoize(_createS3Client)
 
+/**
+ * Per-gitdir cache of the git-annex branch OID. The git-annex ref is read
+ * once per dataset; without this, every annex pointer resolution re-runs
+ * resolveRef + the underlying pack-file decoding.
+ */
+const annexRefCache = new Map<string, Promise<string>>()
+
+function getAnnexRef(
+  // deno-lint-ignore no-explicit-any
+  options: Record<string, any>,
+): Promise<string> {
+  const key = options?.gitdir ?? ''
+  let oidPromise = annexRefCache.get(key)
+  if (!oidPromise) {
+    // deno-lint-ignore no-explicit-any
+    oidPromise = git.resolveRef({ ref: 'git-annex', ...options } as any).catch((err) => {
+      // Allow retry on the next call by evicting failed lookups.
+      annexRefCache.delete(key)
+      throw err
+    })
+    annexRefCache.set(key, oidPromise)
+  }
+  return oidPromise
+}
+
 export async function readAnnexPath(
   filepath: string,
   // deno-lint-ignore no-explicit-any
   options: Record<string, any>,
 ): Promise<string> {
-  // deno-lint-ignore no-explicit-any
-  const oid = await git.resolveRef({ ref: 'git-annex', ...options } as any)
+  const oid = await getAnnexRef(options)
   // deno-lint-ignore no-explicit-any
   const { blob } = await git.readBlob({ oid, filepath, ...options } as any)
   return textDecoder.decode(blob)


### PR DESCRIPTION
## Summary

Two small, behavior-preserving changes to how the Deno validator interacts with `isomorphic-git` when walking datasets that contain git-annex pointers (DataLad / git-annex repositories). Together they cut CPU cost on a representative DataLad dataset by ~2.7× without changing any validation output.

## Motivation

While profiling the validator on a typical DataLad-managed dataset (`ds005016`: 147 subjects, ~6,900 files, 2,397 NIfTI annex pointers, 2,370 of them with content not fetched), the V8 profile showed validation was completely dominated by git pack-file decompression rather than by the BIDS rule engine.

Top hot spots (V8 `--prof`, 44,077 ticks):

- `pako` zlib `inflate_fast` / `inflate` / `inflate_table`: ~5%
- `isomorphic-git` `parseBuffer` / `fromIdx` / `comparePath` / `normalizeString`: ~6%
- `Buffer` `hexSlice` / `bidirectionalIndexOf` / `toString`: ~5%
- BIDS rule engine (`_applyRules`, `expressionLanguage`, `filenameIdentify`): well under 1%

Two structural causes:

1. **A fresh `cache: {}` was being created for `isomorphic-git` per recursive call into `_readFileTree`.** Pack-file index and inflated objects were re-loaded for every directory's worth of annex pointers instead of being shared across the whole walk.
2. **`git.resolveRef({ ref: 'git-annex' })` was being called once per `readAnnexPath`.** With thousands of broken annex pointers, the annex branch was being re-resolved thousands of times.

A control experiment — hiding `.git/` before running the same validator — confirmed git work was the dominant cost: wall time dropped from ~110s to 7.2s, with the issue count unchanged.

## Changes

### 1. `src/files/deno.ts` — share `isomorphic-git` cache across the entire walk

`_readFileTree` previously allocated `const cache = {}` inside each recursive call. That cache is captured by `AnnexedGitFileOpener` via `{ cache, fs, gitdir }`, so it survives for the lifetime of the openers — but only the openers from one directory share it; openers in sibling directories get unrelated caches.

This patch threads a single `gitCaches: Map<gitdir, object>` through the recursion. The top-level call allocates the map; recursive calls forward it. Per annex symlink, we look up (or lazily create) the cache for that file's `gitdir` and pass it into the `AnnexedGitFileOpener`'s options.

Keying by `gitdir` (rather than using one global cache for the dataset) keeps the semantics correct if a dataset contains submodules or out-of-tree symlinks pointing into separate annex stores — each `.git/` directory gets its own cache. In practice, on a typical single-repo dataset, all annex pointers share the same map entry.

### 2. `src/files/repo.ts` — memoize the `git-annex` ref OID per gitdir

`readAnnexPath` previously called `git.resolveRef({ ref: 'git-annex', ... })` on every invocation. For a dataset with N broken annex pointers, that's N calls; each one re-walks refs in the underlying isomorphic-git store.

This patch adds a module-level `annexRefCache: Map<gitdir, Promise<string>>`. The first call for a given gitdir kicks off `resolveRef` and stores the in-flight promise; subsequent calls await the cached promise. Failures are evicted so retries still go through. The cache holds promises (not resolved values) intentionally — concurrent first calls share one in-flight `resolveRef` rather than racing.

## Scope: what this PR does *not* change

- **No validation output changes.** Issue counts are identical before/after on every dataset tested. The BIDS rule engine, expression language, schema loading, filename validation, JSON/TSV checks, NIfTI header handling — all untouched.
- **No new flags or API.** Internal-only refactor.
- **No change to the HTTP-fetch-on-missing-annex path.** The validator still tries to resolve a presigned S3 URL via `AnnexedGitFileOpener` when a local annex object is absent, and still HTTP-fetches headers from it. That path is the dominant remaining wall-time cost on DataLad datasets with un-fetched content, but changing it is a policy question that's worth a separate discussion.
- **No effect on non-DataLad datasets.** Both code paths are gated on the presence of annex pointer symlinks; on plain BIDS datasets the `gitCaches` map is allocated but never populated, and `annexRefCache` is never consulted.

## Test plan

All existing tests pass:

```
deno test -A src/files/deno.test.ts src/files/repo.test.ts src/files/git.test.ts
# 27 passed (13 steps) | 0 failed (27s)
```

The `git.test.ts` integration suite clones `ds000001` as both bare and full repos with `git-annex init` + one locally-present annex object, then validates via three different code paths (`readGitTree` bare, `readGitTree` full, `readFileTree` work-tree). All three continue to produce the exact same single expected issue.

Reviewers may want to additionally verify on a representative DataLad dataset of their choice that issue counts are unchanged. I used `ds005016` (147 subjects, broken-annex-heavy) and got 17,692 issues both before and after, with no diff in `code`/`subCode`/`location`/`severity`.

## Benchmarks

Dataset: `ds005016` (147 subjects, 4,519 regular files + 2,379 symlinks, 2,380 JSON sidecars, 1,348 TSVs, 2,397 NIfTI files of which only 9 have annex content locally present). Three warm runs each, `deno 2.7.14`, macOS arm64.

| Configuration | Wall (s) | User CPU (s) | CPU util |
| --- | ---: | ---: | ---: |
| `main`, default flags | 107–122 | 77–79 | 68–75% |
| this PR, default flags | 80–95 | 29–30 | ~37% |
| `main`, `--ignoreNiftiHeaders` | 5.1–5.4 | 5.1–5.4 | ~99% |
| this PR, `--ignoreNiftiHeaders` | 5.1–5.4 | 5.1–5.4 | ~99% |

Headline: **CPU cost on the default path drops ~2.7×.** Wall time drops ~25% because the remainder is HTTP fetches to the S3 remote for missing annex content (unchanged by this PR).

The `--ignoreNiftiHeaders` rows are identical because annex resolution is lazy — when content is never read, the resolution path is never entered, so this patch has nothing to do.

## Files changed

```
 src/files/deno.ts | 21 +++++++++++++++++++--
 src/files/repo.ts | 28 ++++++++++++++++++++++++--
 2 files changed, 45 insertions(+), 4 deletions(-)
```

## Reviewer questions

1. The `annexRefCache` is module-level (process-global). The validator is short-lived enough that this is fine, and it correctly keys by `gitdir`, but if there's a future use case for running multiple independent validations in one process, this cache should move onto an options object. Acceptable as-is, or worth restructuring now?
2. `gitCaches` is keyed by `gitdir`. Today only one gitdir is ever produced per dataset by `gitdirFromLink`, so the map has at most one entry. The map-of-caches structure exists to keep behavior correct if that ever changes (submodules, cross-store symlinks). Happy to simplify to a single cache if the consensus is that multiple gitdirs in one dataset is out of scope.
3. The HTTP-fetch-on-missing-annex question — should that be a follow-up PR with `--no-annex-fetch` or similar?