### PR TITLE
Minor test corrections to accommodate windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 bids-validator/src/.git-meta.json  export-subst
+src/tests/bom-utf8.json  text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,10 +55,13 @@ for their contributions to this release.
 
 ## Fixed
 
-- Test suite now passes on Windows: `src/tests/bom-utf8.json` is pinned to LF
-  line endings via `.gitattributes` (previously checked out as CRLF, breaking the
-  BOM-stripping assertion), and `chmod -R +w` cleanup calls in
-  `src/files/git.test.ts` and `src/files/utils.test.ts` are skipped on Windows
+- Test suite now passes on Windows: `src/tests/bom-utf8.json`
+  is pinned to LF line endings via `.gitattributes` 
+  (previously checked out as CRLF, breaking the
+  BOM-stripping assertion).
+  
+- `chmod -R +w` cleanup calls in`src/files/git.test.ts` and 
+  `src/files/utils.test.ts` are skipped on Windows
   where `chmod` is not available.
 
 - Use absolute path to `.js` within Dockerfile ENTRYPOINT,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ for their contributions to this release.
 
 ## Fixed
 
+- Test suite now passes on Windows: `src/tests/bom-utf8.json` is pinned to LF
+  line endings via `.gitattributes` (previously checked out as CRLF, breaking the
+  BOM-stripping assertion), and `chmod -R +w` cleanup calls in
+  `src/files/git.test.ts` and `src/files/utils.test.ts` are skipped on Windows
+  where `chmod` is not available.
+
 - Use absolute path to `.js` within Dockerfile ENTRYPOINT,
   so could be found by singularity execution from arbitrary
   working directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,11 @@ for their contributions to this release.
 ## Fixed
 
 - Test suite now passes on Windows: `src/tests/bom-utf8.json`
-  is pinned to LF line endings via `.gitattributes` 
+  is pinned to LF line endings via `.gitattributes`
   (previously checked out as CRLF, breaking the
   BOM-stripping assertion).
-  
-- `chmod -R +w` cleanup calls in`src/files/git.test.ts` and 
+
+- `chmod -R +w` cleanup calls in`src/files/git.test.ts` and
   `src/files/utils.test.ts` are skipped on Windows
   where `chmod` is not available.
 

--- a/src/files/deno.test.ts
+++ b/src/files/deno.test.ts
@@ -1,7 +1,6 @@
 import { assert, assertEquals, assertRejects } from '@std/assert'
 import { readAll, readerFromStreamReader } from '@std/io'
 import { basename, dirname, fromFileUrl, join } from '@std/path'
-import { EOL } from '@std/fs'
 import type { FileTree } from '../types/filetree.ts'
 import { BIDSFileDeno, readFileTree } from './deno.ts'
 import { UnicodeDecodeError } from './streams.ts'
@@ -62,7 +61,7 @@ Deno.test('Deno implementation of BIDSFile', async (t) => {
       const bomFilename = 'bom-utf8.json'
       const file = new BIDSFileDeno(bomDir, bomFilename, ignore)
       const text = await file.text()
-      assertEquals(text, ['{', '  "example": "JSON for test suite"', '}', ''].join(EOL))
+      assertEquals(text, ['{', '  "example": "JSON for test suite"', '}', ''].join('\n'))
     },
   )
 })

--- a/src/files/git.test.ts
+++ b/src/files/git.test.ts
@@ -96,9 +96,11 @@ Deno.test(
       })
     } finally {
       // git/git-annex sets some objects read-only; chmod +w before removal
-      await new Deno.Command('chmod', {
-        args: ['-R', '+w', tmpDir],
-      }).output()
+      if (!isWindows) {
+        await new Deno.Command('chmod', {
+          args: ['-R', '+w', tmpDir],
+        }).output()
+      }
       await Deno.remove(tmpDir, { recursive: true })
     }
   },
@@ -393,7 +395,9 @@ Deno.test(
       assertExists(data, 'data.txt should be in tree')
       assertEquals(await (data as BIDSFile).text(), 'bare test')
     } finally {
-      await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()
+      if (!isWindows) {
+        await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()
+      }
       await Deno.remove(tmpDir, { recursive: true })
     }
   },

--- a/src/files/utils.test.ts
+++ b/src/files/utils.test.ts
@@ -59,7 +59,9 @@ export async function withRepo(
     await run(['git', '-C', tmpDir, 'commit', '--no-gpg-sign', '-m', 'init'])
     await test(tmpDir)
   } finally {
-    await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()
+    if (!isWindows) {
+      await new Deno.Command('chmod', { args: ['-R', '+w', tmpDir] }).output()
+    }
     await Deno.remove(tmpDir, { recursive: true })
   }
 }


### PR DESCRIPTION
## Summary

Fixes five tests that fail on Windows due to CRLF line endings and unconditional `chmod` calls.

## Root causes

### 1. CRLF line endings in `bom-utf8.json`

The BOM-stripping test in `deno.test.ts` compared `.text()` output against a string joined with the platform `EOL` constant from `@std/fs`. On Windows `EOL` is `\r\n`, but `bom-utf8.json` is stored in git with LF-only line endings. With `core.autocrlf=true`, git converts the file to CRLF on checkout, causing the assertion to fail.

### 2. `chmod` called on Windows in `finally` blocks

Three `finally` blocks called `chmod -R +w` unconditionally as part of temp-directory cleanup. `chmod` does not exist on Windows, so these calls threw `NotFound`, prevented `Deno.remove()` from running, and caused the tests to fail.

## Changes

| File | Change |
|---|---|
| `.gitattributes` | Mark `src/tests/bom-utf8.json` as `text eol=lf` so git enforces LF for all contributors regardless of `core.autocrlf` |
| `src/files/deno.test.ts` | Replace `join(EOL)` with `join('\n')` and remove the now-unused `EOL` import — the fixture has a known fixed encoding, platform-adaptive EOL is wrong here |
| `src/files/utils.test.ts` | Guard the `chmod` call in `withRepo` with `if (!isWindows)` |
| `src/files/git.test.ts` | Guard the `chmod` calls in the `finally` blocks of the ds000001 integration test and the bare-repository test with `if (!isWindows)` |

## Tests

Previously failing on Windows:

- `Deno implementation of BIDSFile … strips BOM characters when reading UTF-8 via .text()`
- `readGitTree: error on nonexistent ref`
- `readGitTree: abbreviated SHA resolution`
- `readGitTree: pruning directories`
- `readGitTree: bare repository`

All five now pass. The `chmod` calls still run on Linux/macOS (the guard is Windows-only), so behaviour there is unchanged.