### PR TITLE
fix: Parse V8 and WebKit stack traces explicitly

### DIFF
--- a/changelog.d/20260520_095221_markiewicz_webkit_stack_trace.md
+++ b/changelog.d/20260520_095221_markiewicz_webkit_stack_trace.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Debug logging is fixed for WebKit-based runners, such as Safari or Tauri.
+  Issue reported by Chris Rorden in [#405][].
+
+[#405]: https://github.com/bids-standard/bids-validator/pull/405

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -29,4 +29,23 @@ Deno.test('logger', async (t) => {
       'loadHeader (file:///bids-validator/bids-validator/src/files/nifti.ts:18:12)',
     )
   })
+  await t.step('test stack trace behavior for webkit format', () => {
+    const stack = `get@file:///bids-validator/src/utils/logger.ts:30:32
+validate@file:///bids-validator/src/validators/bids.ts:110:18
+`
+    assertEquals(
+      parseStack(stack),
+      'validate (file:///bids-validator/src/validators/bids.ts:110:18)',
+    )
+  })
+  await t.step('test stack trace behavior for unknown format', () => {
+    // Just making this one up to be plausible but not real
+    const stack = `get() (defined at file:///bids-validator/src/utils/logger.ts:30:32)
+called from validate() (defined at file:///bids-validator/src/validators/bids.ts:110:18)
+`
+    assertEquals(parseStack(stack), undefined)
+  })
+  await t.step('Does not throw on empty stack', () => {
+    assertEquals(parseStack(''), undefined)
+  })
 })

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -18,11 +18,19 @@ export function setupLogging(level: LevelName) {
   })
 }
 
-export function parseStack(stack: string) {
+export function parseStack(stack: string): string | undefined {
   const lines = stack.split('\n')
-  const caller = lines[2].trim()
-  const token = caller.split('at ')
-  return token[1]
+  if (lines[0].trim() === 'Error') {
+    // V8 stack trace format
+    const caller = lines[2].trim()
+    const token = caller.split('at ')
+    return token[1]
+  } else if (lines[0].match(/^\w+@/)) {
+    // WebKit stack trace format
+    const caller = lines[1].trim()
+    const token = caller.split('@')
+    return `${token[0]} (${token[1]})`
+  }
 }
 
 const loggerProxyHandler = {
@@ -31,7 +39,7 @@ const loggerProxyHandler = {
     const logger = getLogger('@bids/validator')
     const stack = new Error().stack
     if (stack) {
-      const callerLocation = parseStack(stack)
+      const callerLocation = parseStack(stack) ?? '<unknown>'
       logger.debug(`Logger invoked at "${callerLocation}"`)
     }
     const logFunc = logger[prop] as typeof logger.warn


### PR DESCRIPTION
A detailed write-up of the issue is in #405, but the fix there aims at suppressing the error rather than replicating current functionality with the alternative stack trace format.

This PR explicitly handles the different stack trace formats and aims to produce the same output for the same code paths in the different engines.

Closes #405.