### PR TITLE
fix: Prune dotfiles rather than ignore, make `--prune` inject default ignores into prune list

### DIFF
--- a/changelog.d/20260602_211743_markiewicz_prune_git.md
+++ b/changelog.d/20260602_211743_markiewicz_prune_git.md
@@ -1,0 +1,11 @@
+### Changed
+
+- The `--prune` option removes opaque BIDS directories (`sourcedata/`, `derivatives/`, etc.)
+  from the file tree, reducing processing time and memory usage.
+  This option is incompatible with recursive validation and may cause unexpected
+  behavior if pruned data are referenced by name or via symbolic links.
+
+### Fixed
+
+- `.dotfiles` and directories (such as `.git/`) are now pruned from the file tree,
+  avoiding unnecessary IO operations and memory consumption.

--- a/src/api/filetree/mod.ts
+++ b/src/api/filetree/mod.ts
@@ -15,3 +15,4 @@
 export { FileTree } from '../../types/filetree.ts'
 export { filesToTree, loadBidsIgnore, subtree } from '../../files/filetree.ts'
 export { FileIgnoreRules, readBidsIgnore } from '../../files/ignore.ts'
+export type { IgnoreGroup, LogOptions } from '../../files/ignore.ts'

--- a/src/files/browser.ts
+++ b/src/files/browser.ts
@@ -41,7 +41,7 @@ export function fileListToTree(
   return loadBidsIgnore(
     filesToTree(
       files.map((f) => new BIDSFileBrowser(f, ignore, root))
-        .filter((f) => !prune.test(f.path)),
+        .filter((f) => !prune.test(f.path, { log: true, prefix: 'Pruned' })),
       ignore,
     ),
     ignore,

--- a/src/files/browser.ts
+++ b/src/files/browser.ts
@@ -31,11 +31,19 @@ export class BIDSFileBrowser extends BIDSFile {
  * @param files - Files selected via the browser file picker.
  * @returns The root `FileTree` with `.bidsignore` rules applied.
  */
-export function fileListToTree(files: File[]): Promise<FileTree> {
+export function fileListToTree(
+  files: File[],
+  prune?: FileIgnoreRules,
+): Promise<FileTree> {
+  prune ??= new FileIgnoreRules([], 'prune')
   const ignore = new FileIgnoreRules([])
   const root = new FileTree('/', '/', undefined)
   return loadBidsIgnore(
-    filesToTree(files.map((f) => new BIDSFileBrowser(f, ignore, root)), ignore),
+    filesToTree(
+      files.map((f) => new BIDSFileBrowser(f, ignore, root))
+        .filter((f) => !prune.test(f.path)),
+      ignore,
+    ),
     ignore,
   )
 }

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -71,7 +71,7 @@ async function _readFileTree({
 
   for await (const dirEntry of Deno.readDir(join(rootPath, relativePath))) {
     const thisPath = posix.join(relativePath, dirEntry.name)
-    if (prune.test(thisPath)) {
+    if (prune.test(thisPath, { log: true, prefix: 'Pruned' })) {
       continue
     }
 

--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -155,7 +155,7 @@ export async function readFileTree(
   prune?: FileIgnoreRules,
   preferredRemote?: string,
 ): Promise<FileTree> {
-  prune ??= new FileIgnoreRules([], false)
+  prune ??= new FileIgnoreRules([], 'prune')
   const ignore = new FileIgnoreRules([])
   const tree = await _readFileTree({ rootPath, relativePath: '/', ignore, prune, preferredRemote })
   return loadBidsIgnore(tree, ignore)

--- a/src/files/filetree.test.ts
+++ b/src/files/filetree.test.ts
@@ -152,11 +152,14 @@ Deno.test('extract subtrees', async (t) => {
     subignore.opener = new StringOpener('also_ignored_file\n')
 
     assertEquals(tree.get('ignored_file')!.ignored, true)
-    assertEquals(tree.get('derivatives/pipeline/also_ignored_file')!.ignored, false)
+    // All derivatives files are ignored by the root
+    assertEquals(tree.get('derivatives/pipeline/also_ignored_file')!.ignored, true)
 
     const pipeline = await subtree(tree.get('derivatives/pipeline') as FileTree)
-    assertEquals(pipeline.get('also_ignored_file')!.ignored, true)
+    // The top-level ignored_file is no longer ignored in the subtree
     assertEquals(pipeline.get('ignored_file')!.ignored, false)
+    // The subtree's .bidsignore still catches also_ignored_file
+    assertEquals(pipeline.get('also_ignored_file')!.ignored, true)
   })
 })
 

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -243,6 +243,7 @@ export async function readGitTree(
   const { commit, gitOptions } = await resolveRef(repoPath, ref)
 
   const ignore = new FileIgnoreRules([])
+  prune ??= new FileIgnoreRules([], 'prune')
   const files: BIDSFile[] = []
   const symlinkMap = new Map<string, string>()
   const deferredSymlinks: { filepath: string; target: string }[] = []

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -270,7 +270,7 @@ export async function readGitTree(
         if (entryType !== 'blob') return null
 
         // Prune check for files
-        if (prune && prune.test('/' + filepath)) return null
+        if (prune.test('/' + filepath, { log: true, prefix: 'Pruned' })) return null
 
         const oid = await entry.oid()
         const mode = await entry.mode()

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -288,7 +288,7 @@ async function walkSubtree(
       ? `/${entry.path}`
       : `${graftPath}/${entry.path}`
 
-    if (prune && prune.test(outPath)) continue
+    if (prune?.test(outPath, { log: true, prefix: 'Pruned' })) continue
 
     if (entry.type === 'tree') {
       // Recurse with the child outPath as the new graftPath and the

--- a/src/files/ignore.test.ts
+++ b/src/files/ignore.test.ts
@@ -58,4 +58,23 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
     const filtered = files.filter((path) => !ignore.test(path))
     assertEquals(filtered.length, 0)
   })
+  await t.step('Default groups may be added post-init', () => {
+    const files = [
+      '/derivatives/pipeline/file.nii',
+      '/sourcedata/sub-01/anat/T1w.dcm',
+      '/.git/HEAD',
+      '/.datalad/config',
+      '/.gitignore',
+      '/sub-01/.gitignore',
+      '/sub-01/.DS_Store',
+      '/sub-01/.cache/file',
+      '/sub-01/anat/sub-01_T1w.nii.gz',
+    ]
+    const ignore = new FileIgnoreRules([], false)
+    assertEquals(files.filter((path) => !ignore.test(path)).length, 9)
+    ignore.addDefaults('ignore')
+    assertEquals(files.filter((path) => !ignore.test(path)).length, 7)
+    ignore.addDefaults('prune')
+    assertEquals(files.filter((path) => !ignore.test(path)).length, 1)
+  })
 })

--- a/src/files/ignore.test.ts
+++ b/src/files/ignore.test.ts
@@ -58,6 +58,15 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
     const filtered = files.filter((path) => !ignore.test(path))
     assertEquals(filtered.length, 0)
   })
+  await t.step('Default prune does not prune .bidsignore', () => {
+    const ignore = new FileIgnoreRules([], 'prune')
+    assertEquals(ignore.test('/.bidsignore'), false)
+  })
+  await t.step('Adding default ignores does not prune .bidsignore', () => {
+    const ignore = new FileIgnoreRules([], 'prune')
+    ignore.addDefaults('ignore')
+    assertEquals(ignore.test('/.bidsignore'), false)
+  })
   await t.step('Default groups may be added post-init', () => {
     const files = [
       '/derivatives/pipeline/file.nii',

--- a/src/files/ignore.test.ts
+++ b/src/files/ignore.test.ts
@@ -10,7 +10,6 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
       '/CHANGES',
       '/participants.tsv',
       '/.git/HEAD',
-      '/.datalad/config',
       '/sub-01/anat/non-bidsy-file.xyz',
       '/explicit/full/path.nii',
     ]
@@ -24,5 +23,39 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
       '/CHANGES',
       '/participants.tsv',
     ])
+  })
+  await t.step('Default ignores ignore opaque BIDS directories', () => {
+    const files = [
+      // Ignored directories
+      '/derivatives/pipeline/file.nii',
+      '/sourcedata/sub-01/anat/T1w.dcm',
+      '/code/script.py',
+      '/stimuli/image.png',
+      '/log/run.log',
+      '/doc/SOP.md',
+      // Only ignored at top level
+      '/sub-01/derivatives/pipeline/file.nii',
+      '/sub-01/sourcedata/sub-01/anat/T1w.dcm',
+      '/sub-01/code/script.py',
+      '/sub-01/stimuli/image.png',
+      '/sub-01/log/run.log',
+      '/sub-01/doc/SOP.md',
+    ]
+    const ignore = new FileIgnoreRules([])
+    const filtered = files.filter((path) => !ignore.test(path))
+    assertEquals(filtered.length, 6)
+  })
+  await t.step('Default prunes ignore dotfiles at all levels', () => {
+    const files = [
+      '/.git/HEAD',
+      '/.datalad/config',
+      '/.gitignore',
+      '/sub-01/.gitignore',
+      '/sub-01/.DS_Store',
+      '/sub-01/.cache/file',
+    ]
+    const ignore = new FileIgnoreRules([], 'prune')
+    const filtered = files.filter((path) => !ignore.test(path))
+    assertEquals(filtered.length, 0)
   })
 })

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -53,9 +53,20 @@ export class FileIgnoreRules {
   ) {
     this.#ignore = ignore()
     if (addDefaults) {
-      this.#ignore.add(ignoreDefaults[group])
+      this.addDefaults(addDefaults)
     }
     this.#ignore.add(config)
+  }
+
+  /**
+   * Add default ignore group to the ignore rules.
+   *
+   * @param group - Group to add to the ignore rules.
+   *   "ignore" ignores opaque BIDS directories at the top level,
+   *   while "prune" ignores dotfiles at all levels.
+   */
+  addDefaults(group: IgnoreGroup): void {
+    this.#ignore.add(ignoreDefaults[group])
   }
 
   /**

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -32,6 +32,7 @@ const ignoreDefaults: Record<IgnoreGroup, string[]> = {
   ],
   'prune': [
     '.**',
+    '!/.bidsignore',
   ],
 }
 

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -1,6 +1,6 @@
+import { default as ignore, type Ignore } from '@ignore'
 import type { BIDSFile } from '../types/filetree.ts'
-import { default as ignore } from '@ignore'
-import type { Ignore } from '@ignore'
+import { logger } from '../utils/logger.ts'
 
 /**
  * Read a `.bidsignore` file and return its lines as ignore patterns.
@@ -20,6 +20,12 @@ export async function readBidsIgnore(file: BIDSFile): Promise<string[]> {
 
 /** Names of rules for either pruning or ignoring files. */
 export type IgnoreGroup = 'ignore' | 'prune'
+
+/** Options for logging ignored files. */
+export type LogOptions = {
+  log?: boolean
+  prefix?: string
+}
 
 const ignoreDefaults: Record<IgnoreGroup, string[]> = {
   'ignore': [
@@ -84,10 +90,16 @@ export class FileIgnoreRules {
    *
    * @param path - Dataset-relative path with a leading `/` (the leading slash
    *   is stripped internally before matching).
+   * @param options - Logging options. If `log` is set, a message is logged.
+   *   `prefix` is prepended to the log message (default: "Ignoring path").
    * @returns `true` if the path is matched by any active ignore pattern.
    */
-  test(path: string): boolean {
+  test(path: string, options?: LogOptions): boolean {
     // Paths come in with a leading slash, but ignore expects paths relative to root
-    return this.#ignore.ignores(path.slice(1, path.length))
+    const ignored = this.#ignore.ignores(path.slice(1, path.length))
+    if (ignored && options?.log) {
+      logger.info(`${options.prefix ?? 'Ignoring path'}: ${path}`)
+    }
+    return ignored
   }
 }

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -18,32 +18,42 @@ export async function readBidsIgnore(file: BIDSFile): Promise<string[]> {
   }
 }
 
-const defaultIgnores = [
-  '.git**',
-  '.*',
-  'sourcedata/',
-  'code/',
-  'stimuli/',
-  'log/',
-]
+/** Names of rules for either pruning or ignoring files. */
+export type IgnoreGroup = 'ignore' | 'prune'
+
+const ignoreDefaults: Record<IgnoreGroup, string[]> = {
+  'ignore': [
+    '/sourcedata/',
+    '/derivatives/',
+    '/code/',
+    '/stimuli/',
+    '/log/',
+    '/doc/',
+  ],
+  'prune': [
+    '.**',
+  ],
+}
 
 /**
  * Gitignore-style path matcher for `.bidsignore` rules.
  *
  * @param config - Array of gitignore-style patterns.
- * @param addDefaults - When `true` (the default), standard BIDS ignores
- *   (`.git**`, `sourcedata/`, `code/`, etc.) are prepended.
+ * @param addDefaults - When set, pre-populate with default ignore groups.
+ *   "ignore" (the default) ignores opaque BIDS directories at the top level,
+ *   while "prune" ignores dotfiles at all levels.
+ *   Set to `false` to disable default rules.
  */
 export class FileIgnoreRules {
   #ignore: Ignore
 
   constructor(
     config: string[],
-    addDefaults: boolean = true,
+    addDefaults: IgnoreGroup | false = 'ignore',
   ) {
     this.#ignore = ignore()
     if (addDefaults) {
-      this.#ignore.add(defaultIgnores)
+      this.#ignore.add(ignoreDefaults[group])
     }
     this.#ignore.add(config)
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,9 +24,13 @@ export async function main(): Promise<ValidationResult> {
   setupLogging(options.debug)
 
   const absolutePath = resolve(options.datasetPath)
-  const prune = options.prune
-    ? new FileIgnoreRules(['derivatives', 'sourcedata', 'code'], false)
-    : undefined
+  const prune = new FileIgnoreRules([], 'prune')
+  if (options.prune) {
+    // Opaque BIDS directories are ignored by default but still included to allow lookups,
+    // including size estimates and symlink resolution in git trees.
+    // Pruning is an extreme measure to reduce memory usage and IO ops and may have unintended consequences.
+    prune.addDefaults('ignore')
+  }
   const tree = options.gitRef
     ? await readGitTree(absolutePath, options.gitRef, prune, options.preferredRemote)
     : await readFileTree(absolutePath, prune, options.preferredRemote)

--- a/src/setup/options.ts
+++ b/src/setup/options.ts
@@ -57,7 +57,7 @@ export type ValidatorOptions = {
   datasetTypes: string[]
   /** Modalities to refuse; validation fails if any of these are detected. */
   blacklistModalities: string[]
-  /** When `true`, remove files matched by `.bidsignore` from the tree before validation. */
+  /** When `true`, remove opaque directories (e.g., sourcedata/, derivatives/) before validation. */
   prune?: boolean
   /** Row cap for TSV validation; `0` validates headers only; unset or `-1` validates all rows. */
   maxRows?: number
@@ -143,7 +143,8 @@ export const validateCommand: Command<void, void, any, string[], void> = new Com
   )
   .option(
     '-p, --prune',
-    'Prune derivatives and sourcedata directories on load (disables -r and will underestimate dataset size)',
+    'Prune "opaque" BIDS directories from source tree before validation. ' +
+      'WARNING: This is an extreme measure to reduce memory usage and IO operations but may change the results of validation.',
   )
   .option(
     '-o, --outfile <file:string>',

--- a/src/types/filetree.ts
+++ b/src/types/filetree.ts
@@ -101,7 +101,7 @@ export class BIDSFile {
   /** `true` when the file's path matches the active ignore rules. */
   get ignored(): boolean {
     if (typeof this.#ignore === 'boolean') return this.#ignore
-    return this.#ignore.test(this.path)
+    return this.#ignore.test(this.path) || this.path === '/.bidsignore'
   }
 
   /** File size in bytes, delegated to the underlying {@link FileOpener}. */


### PR DESCRIPTION
Initially narrowly scoped to prune `.git`, this PR now includes the following changes:

* Dotfiles and directories are now pruned during walk, rather than ignored after the walk. This saves descent into `.git/` or other potentially deep hidden directories (`.venv/`, for example).
* `--prune` now injects the default ignore list into the prune list, which is a more principled way to decide what gets pruned.
* To preserve the original intended behavior of `--prune`, `derivatives/` is now ignored.
* To avoid pruning `.bidsignore` and causing `--prune` to un-ignore everything, `.bidsignore` is now ignored through a carve-out in the `BIDSFile.ignored` property. As a validator feature and not a BIDS feature, this seems reasonable to me.
* The file tree builders now all construct a default prune list for consistency.

Open issues (probably for separate PRs):

* Generating the default ignore list from schema. There's a bit of a chicken and egg problem where if the ignore list comes from a newer schema than is declared in `dataset_description.json`, we're not respecting that, but that's already the case. We already don't load the schema based on `dataset_description.json`, so as long as we load it from `--schema`, we're still improving.
* The file count skips ignored files...  With significant confounds like `.git` now being pruned instead of ignored, I think it may be time to revisit this and count ignored files for a more accurate description of dataset size.

Closes #412.