### PR TITLE
rf: Simplify FsFileOpener protocol

### DIFF
--- a/src/files/deno.ts
+++ b/src/files/deno.ts
@@ -26,7 +26,7 @@ import fs from 'node:fs'
  */
 export class BIDSFileDeno extends BIDSFile {
   constructor(datasetPath: string, path: string, ignore?: FileIgnoreRules, parent?: FileTree) {
-    super(path, new FsFileOpener(datasetPath, path), ignore, parent)
+    super(path, new FsFileOpener(join(datasetPath, path)), ignore, parent)
   }
 }
 
@@ -119,7 +119,7 @@ async function _readFileTree({
     }
 
     if (isFile) {
-      const opener = new FsFileOpener(rootPath, thisPath, fileInfo)
+      const opener = new FsFileOpener(join(rootPath, thisPath), fileInfo)
       tree.files.push(new BIDSFile(thisPath, opener, ignore, tree))
     } else if (isDirectory) {
       const dirTree = await _readFileTree({

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -136,7 +136,7 @@ export class AnnexedGitFileOpener implements FileOpener {
     )
     try {
       const fileInfo = await Deno.stat(localPath)
-      this.#delegate = new FsFileOpener('', localPath, fileInfo)
+      this.#delegate = new FsFileOpener(localPath, fileInfo)
       return this.#delegate
     } catch {
       // Local object not present; fall through to remote resolution

--- a/src/files/openers.ts
+++ b/src/files/openers.ts
@@ -4,7 +4,6 @@
  * These classes implement stream, text and random bytes access to BIDS resources.
  */
 import { retry } from '@std/async'
-import { join } from '@std/path'
 import type { FileOpener } from '../types/filetree.ts'
 import { createUTF8Stream } from './streams.ts'
 import { logger } from '../utils/logger.ts'
@@ -26,8 +25,8 @@ export class FsFileOpener implements FileOpener {
   /** Cached `Deno.FileInfo` object. */
   fileInfo!: Deno.FileInfo
 
-  constructor(datasetPath: string, path: string, fileInfo?: Deno.FileInfo) {
-    this.path = join(datasetPath, path)
+  constructor(path: string, fileInfo?: Deno.FileInfo) {
+    this.path = path
     if (fileInfo) {
       this.fileInfo = fileInfo
     } else {

--- a/src/files/openers.ts
+++ b/src/files/openers.ts
@@ -75,11 +75,10 @@ export class FsFileOpener implements FileOpener {
    * @param offset - Byte offset at which to start reading (default `0`).
    */
   async readBytes(size: number, offset = 0): Promise<Uint8Array<ArrayBuffer>> {
-    const handle = await this.open()
+    using handle = await this.open()
     const buf = new Uint8Array(size)
     await handle.seek(offset, Deno.SeekMode.Start)
     const nbytes = await handle.read(buf) ?? 0
-    await handle.close()
     return buf.subarray(0, nbytes)
   }
 


### PR DESCRIPTION
`FsFileOpener` has no need to duplicate the split between dataset path and relative path of `BIDSFileDeno`.

Was bugged by this during #414 but didn't want to pollute that PR. If we want to do this, it would be nice to do it before we expose this as public API.