### PR TITLE
fix(wheel): Target OSX 12.0

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: '10.12'
+  MACOSX_DEPLOYMENT_TARGET: '12.0'
 
 defaults:
   run:

--- a/changelog.d/20260630_101533_markiewicz_fix_wheels.md
+++ b/changelog.d/20260630_101533_markiewicz_fix_wheels.md
@@ -1,0 +1,4 @@
+### Infrastructure
+
+- PyPI wheels now set a minimum Python of 3.10.
+- OSX wheels now require a minimum macOS version of 12.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ excludes = [".*"]
 scripts = ["scripts/*"]
 
 [tool.cibuildwheel]
-build = "cp39-*"
+build = "cp310-*"
 # Deno requires glibc, so the alpine package doesn't give us musllinux yet
 # Deno will not build for 32-bit architectures
 skip = "*musllinux* *_i686 *-win32"


### PR DESCRIPTION
CI is failing with

```

  + delocate-wheel --require-archs x86_64 -w /private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/cibw-run-xtcz2cbi/cp39-macosx_x86_64/repaired_wheel -v /private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/cibw-run-xtcz2cbi/cp39-macosx_x86_64/built_wheel/bids_validator_deno-3.0.0a3-py2.py3-none-macosx_10_9_x86_64.whl
  Fixing: /private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/cibw-run-xtcz2cbi/cp39-macosx_x86_64/built_wheel/bids_validator_deno-3.0.0a3-py2.py3-none-macosx_10_9_x86_64.whl
  Traceback (most recent call last):
    File "/private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/cibw-run-xtcz2cbi/cp39-macosx_x86_64/build/venv/bin/delocate-wheel", line 7, in <module>
      sys.exit(main())
    File "/private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/cibw-run-xtcz2cbi/cp39-macosx_x86_64/build/venv/lib/python3.9/site-packages/delocate/cmd/delocate_wheel.py", line 115, in main
      copied = delocate_wheel(
    File "/private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/cibw-run-xtcz2cbi/cp39-macosx_x86_64/build/venv/lib/python3.9/site-packages/delocate/delocating.py", line 1106, in delocate_wheel
      out_wheel_fixed = _check_and_update_wheel_name(
    File "/private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/cibw-run-xtcz2cbi/cp39-macosx_x86_64/build/venv/lib/python3.9/site-packages/delocate/delocating.py", line 928, in _check_and_update_wheel_name
      raise DelocationError(
  delocate.libsana.DelocationError: Library dependencies do not satisfy target MacOS version 10.12:
  /private/var/folders/6x/bw25zx1s3p5655vw5gd7c8j40000gn/T/tmpkhdxmfro/wheel/bids_validator_deno-3.0.0a3.data/scripts/bids-validator-deno has a minimum target of 12.0
  Set the environment variable 'MACOSX_DEPLOYMENT_TARGET=12.0' to update minimum supported macOS for this wheel.
```

Looks like it's time to bump some minimum versions. Dropping EOL Python 3.9 as well.