### PR TITLE
fix: Fully invert logical condition

### DIFF
--- a/src/schema/applyRules.ts
+++ b/src/schema/applyRules.ts
@@ -205,7 +205,7 @@ function evalJsonCheck(
 
     if (value === undefined) {
       const severity = getFieldSeverity(requirement, context)
-      if (severity && (severity === 'ignore')) {
+      if (!severity || severity === 'ignore') {
         continue
       }
 


### PR DESCRIPTION
This narrowly addresses the issue in #434, however it does not address @psadil's larger point that deprecated fields should be addressed.

b6635d3 inverted an if block to continue, to allow for more intricate logic afterwards. The full expression was not inverted, leading to cases where deprecated fields were behaving like recommended fields, because deprecated mapped onto undefined.

Handling deprecations is its own feature that needs consideration, so for now just complete the logic inversion.