### PR TITLE
chore(ci): Drop test.pypi.org upload

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,27 +78,6 @@ jobs:
         working-directory: tests/data/bids-examples
         run: bash run_tests.sh
 
-  test-publish:
-    name: Publish to test.pypi.org
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    needs: [test-wheel]
-    permissions:
-      id-token: write
-
-    steps:
-      - name: Download packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: Packages
-          path: dist
-
-      - name: Upload package to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
-
   publish:
     name: Publish
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
It was [not announced][0] that test.pypi.org was definitely going down, but recommended to find alternative means of testing packaging. Unclear what those tests are supposed to be, but we've got this package figured out, so might as well remove something that will probably start failing.

[0]: https://discuss.python.org/t/restricting-open-ended-releases-on-pypi/43566/89