### PR TITLE
fix: Check hashDirMixed paths in AnnexedGitFileOpener

### DIFF
--- a/changelog.d/20260717_145649_nell_hashdirmixed_lookup.md
+++ b/changelog.d/20260717_145649_nell_hashdirmixed_lookup.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- Support hashDirMixed for local files in AnnexedGitFileOpener
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -18,7 +18,7 @@ import {
 } from '../types/filetree.ts'
 import { filesToTree, loadBidsIgnore } from './filetree.ts'
 import { FileIgnoreRules } from './ignore.ts'
-import { hashDirLower, parseAnnexKey, resolveAnnexedFile } from './repo.ts'
+import { hashDirLower, hashDirMixed, parseAnnexKey, resolveAnnexedFile } from './repo.ts'
 import { FsFileOpener, HTTPOpener, NullFileOpener } from './openers.ts'
 import { streamFromUint8Array } from './streams.ts'
 import { graftTree, MAX_SYMLINK_FOLLOWS, resolveSymlink } from './gitResolver.ts'
@@ -124,8 +124,9 @@ export class AnnexedGitFileOpener implements FileOpener {
     }
 
     // 1. Try local annex object store
-    const [h0, h1] = await hashDirLower(this.#key)
-    const localPath = join(
+    // git-annex tests hashDirMixed first
+    const [h0, h1] = await hashDirMixed(this.#key)
+    const hashDirMixedPath = join(
       this.#gitOptions.gitdir,
       'annex',
       'objects',
@@ -135,11 +136,28 @@ export class AnnexedGitFileOpener implements FileOpener {
       this.#key,
     )
     try {
-      const fileInfo = await Deno.stat(localPath)
-      this.#delegate = new FsFileOpener(localPath, fileInfo)
+      const fileInfo = await Deno.stat(hashDirMixedPath)
+      this.#delegate = new FsFileOpener(hashDirMixedPath, fileInfo)
       return this.#delegate
     } catch {
-      // Local object not present; fall through to remote resolution
+      // Fallback to hashDirLower
+      try {
+        const [h0, h1] = await hashDirLower(this.#key)
+        const hashDirLowerPath = join(
+          this.#gitOptions.gitdir,
+          'annex',
+          'objects',
+          h0,
+          h1,
+          this.#key,
+          this.#key,
+        )
+        const fileInfo = await Deno.stat(hashDirLowerPath)
+        this.#delegate = new FsFileOpener(hashDirLowerPath, fileInfo)
+        return this.#delegate
+      } catch {
+        // Local object not present; fall through to remote resolution
+      }
     }
 
     // 2. Try remote resolution via git-annex metadata

--- a/src/files/repo.ts
+++ b/src/files/repo.ts
@@ -114,6 +114,24 @@ export async function hashDirLower(annexKey: string): Promise<[string, string]> 
   return [digest.slice(0, 3), digest.slice(3, 6)]
 }
 
+/**
+ * git-annex hashDirMixed implementation based on https://git-annex.branchable.com/internals/hashing/
+ */
+export async function hashDirMixed(
+  annexKey: string,
+): Promise<[string, string]> {
+  const computeMD5 = await createMD5()
+  computeMD5.init()
+  computeMD5.update(annexKey)
+  const digest = computeMD5.digest('binary')
+  const firstWord = new DataView(digest.buffer).getUint32(0, true)
+  const nums = Array.from({ length: 4 }, (_, i) => (firstWord >> (6 * i)) & 31)
+  const letters = nums.map(
+    (num) => '0123456789zqjxkmvwgpfZQJXKMVWGPF'.charAt(num),
+  )
+  return [`${letters[1]}${letters[0]}`, `${letters[3]}${letters[2]}`]
+}
+
 export function parseRmetLine(line: string): Rmet | null {
   const match = line.match(rmetLineRegex)
   if (!match) {


### PR DESCRIPTION
Support hashDirMixed in AnnexedGitFileOpener for local files. This matches the git-annex behavior of checking hashDirMixed first before falling back to hashDirLower, but it is more stat calls than just branching on whether or not it's a bare repository. It's possible to have a long lived git-annex repo that uses both so this is the most compatible method.