### PR TITLE
docs: add Yehuda Bergstein to author list

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -28,6 +28,10 @@ authors:
   - family-names: Appelhoff
     given-names: Stefan
     orcid: https://orcid.org/0000-0001-8002-0877
+  - family-names: Bergstein
+    given-names: Yehuda
+    orcid: https://orcid.org/0009-0001-1505-4111
+    affiliation: Tel Aviv University
   - family-names: Bhogawar
     given-names: Suyash
     affiliation: Northern California Institute for Research and Education, San Francisco CA


### PR DESCRIPTION
Adds Yehuda Bergstein to CITATION.cff, as suggested by @effigies in #420.