### PR TITLE
Fix: Correct syntax checking for HED column

### DIFF
--- a/changelog.d/20260827_150743_rosswilsonblair_validate_hed_with_hed_column.md
+++ b/changelog.d/20260827_150743_rosswilsonblair_validate_hed_with_hed_column.md
@@ -1,0 +1,47 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+<!--
+### Changed
+
+- A bullet item for the Changed category.
+
+-->
+### Fixed
+
+- Issue with existence of HED column in context being improperly verified.
+
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -46,7 +46,7 @@ def pdm_build_initialize(context):
             deno,
             "bundle",
             "--frozen",
-            "--sourcemap",
+            "--sourcemap=linked",
             "-o",
             str(bundle),
             "src/bids-validator.ts",

--- a/src/validators/hed.ts
+++ b/src/validators/hed.ts
@@ -62,7 +62,7 @@ export async function hedValidate(
   let isHedFile = false
   if (
     context.extension === '.tsv' && context.columns &&
-    (context.columns.has('HED') || sidecarHasHed(context.sidecar))
+    (Object.keys(context.columns).includes('HED') || sidecarHasHed(context.sidecar))
   ) {
     isHedFile = true
   } else if (context.extension === '.json' && sidecarHasHed(context.json)) {

--- a/src/validators/hed.ts
+++ b/src/validators/hed.ts
@@ -62,7 +62,7 @@ export async function hedValidate(
   let isHedFile = false
   if (
     context.extension === '.tsv' && context.columns &&
-    ('HED' in context.columns || sidecarHasHed(context.sidecar))
+    (context.columns.has('HED') || sidecarHasHed(context.sidecar))
   ) {
     isHedFile = true
   } else if (context.extension === '.json' && sidecarHasHed(context.json)) {


### PR DESCRIPTION
The code checking for the existence of a `HED` column incorrectly used the object-style `in` syntax instead of the `Map`-style `has` method. This was making the check non-functional, resulting in datasets containing a `HED` column but no sidecar HED data to not be validated by hed-validator. This also appears to be causing the error mentioned in https://github.com/hed-standard/hed-javascript/issues/836. This commit fixes the check.