### PR TITLE
Fixes validator crash on NaN summary size for symlinked datasets

### DIFF
--- a/changelog.d/fix_nan_summary.md
+++ b/changelog.d/fix_nan_summary.md
@@ -1,0 +1,2 @@
+### Fixes
+* Fixed validator crash on NaN summary size for symlinked datasets.

--- a/src/summary/summary.ts
+++ b/src/summary/summary.ts
@@ -114,7 +114,10 @@ export class Summary {
     }
 
     this.totalFiles++
-    this.size += await context.file.size
+      const fileSize = await context.file.size
+      if (Number.isFinite(fileSize)){
+        this.size += fileSize
+      }
 
     if ('sub' in context.entities) {
       this.subjects.add(context.entities.sub)

--- a/src/summary/summary.ts
+++ b/src/summary/summary.ts
@@ -114,10 +114,10 @@ export class Summary {
     }
 
     this.totalFiles++
-      const fileSize = await context.file.size
-      if (Number.isFinite(fileSize)) {
-        this.size += fileSize
-      }
+    const fileSize = await context.file.size
+    if (Number.isFinite(fileSize)) {
+      this.size += fileSize
+    }
 
     if ('sub' in context.entities) {
       this.subjects.add(context.entities.sub)

--- a/src/summary/summary.ts
+++ b/src/summary/summary.ts
@@ -115,7 +115,7 @@ export class Summary {
 
     this.totalFiles++
       const fileSize = await context.file.size
-      if (Number.isFinite(fileSize)){
+      if (Number.isFinite(fileSize)) {
         this.size += fileSize
       }
 

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -206,7 +206,7 @@ function formatSummary(summary: SummaryOutput): string {
 
   // data
   const column1 = [
-      summary.totalFiles + ' ' + 'Files' + ', ' + prettyBytes(summary.size),
+      summary.totalFiles + ' ' + 'Files' + ', ' + prettyBytes(Number.isFinite(summary.size)?summary.size:0)
       summary.subjects.length +
       ' - ' +
       'Subjects ' +

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -206,7 +206,7 @@ function formatSummary(summary: SummaryOutput): string {
 
   // data
   const column1 = [
-      summary.totalFiles + ' ' + 'Files' + ', ' + prettyBytes(Number.isFinite(summary.size)?summary.size:0),
+      summary.totalFiles + ' ' + 'Files' + ', ' + prettyBytes(summary.size),
       summary.subjects.length +
       ' - ' +
       'Subjects ' +

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -206,7 +206,7 @@ function formatSummary(summary: SummaryOutput): string {
 
   // data
   const column1 = [
-      summary.totalFiles + ' ' + 'Files' + ', ' + prettyBytes(Number.isFinite(summary.size)?summary.size:0)
+      summary.totalFiles + ' ' + 'Files' + ', ' + prettyBytes(Number.isFinite(summary.size)?summary.size:0),
       summary.subjects.length +
       ' - ' +
       'Subjects ' +


### PR DESCRIPTION
Prevent crash described in Issue #411 

When a dataset contains symlinks, `summary.size` can be NaN, and `prettyBytes` (from @std/fmt/bytes) throws "TypeError: Expected a finite number, got number: NaN", crashing the validator at its summary step.

This guards the value with `Number.isFinite`, falling back to 0 so the summary always renders. Display only change and has no validation logic touched. Thank you! :D