### PR TITLE
feat: Support BEP044 stimulus organization in /stimuli

### DIFF
--- a/changelog.d/20260901_120000_shirazi_bep044_stimuli.md
+++ b/changelog.d/20260901_120000_shirazi_bep044_stimuli.md
@@ -1,0 +1,8 @@
+### Added
+
+- Support for BEP044 stimulus organization in `/stimuli`:
+  files and subdirectories are validated when a `stimuli.tsv` catalog is
+  present anywhere under `/stimuli` (legacy free-form stimuli directories
+  remain exempt), subdirectories of schema directories marked
+  `opaque: false` are permitted, and `UNUSED_STIMULUS` recognizes
+  catalog-tracked stimuli.

--- a/src/files/ignore.test.ts
+++ b/src/files/ignore.test.ts
@@ -30,9 +30,10 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
       '/derivatives/pipeline/file.nii',
       '/sourcedata/sub-01/anat/T1w.dcm',
       '/code/script.py',
-      '/stimuli/image.png',
       '/log/run.log',
       '/doc/SOP.md',
+      // Not ignored: BEP044 stimulus rules apply in /stimuli
+      '/stimuli/image.png',
       // Only ignored at top level
       '/sub-01/derivatives/pipeline/file.nii',
       '/sub-01/sourcedata/sub-01/anat/T1w.dcm',
@@ -43,7 +44,7 @@ Deno.test('Deno implementation of FileIgnoreRules', async (t) => {
     ]
     const ignore = new FileIgnoreRules([])
     const filtered = files.filter((path) => !ignore.test(path))
-    assertEquals(filtered.length, 6)
+    assertEquals(filtered.length, 7)
   })
   await t.step('Default prunes ignore dotfiles at all levels', () => {
     const files = [

--- a/src/files/ignore.ts
+++ b/src/files/ignore.ts
@@ -32,7 +32,8 @@ const ignoreDefaults: Record<IgnoreGroup, string[]> = {
     '/sourcedata/',
     '/derivatives/',
     '/code/',
-    '/stimuli/',
+    // /stimuli/ is not ignored: BEP044 stimulus rules apply there, and
+    // legacy free-form stimuli directories are exempted in hasMatch.
     '/log/',
     '/doc/',
   ],

--- a/src/schema/tables.ts
+++ b/src/schema/tables.ts
@@ -327,7 +327,9 @@ export function evalInitialColumns(
   // Collect the initial columns, index and requirement levels
   // dropping any that are absent but not required
   const columns = rule.initial_columns.map((ruleHeader: string) => {
-    const name = schema.objects.columns[ruleHeader].name
+    // An unknown column key is a schema bug; fall back to the raw key rather
+    // than aborting rule evaluation for the whole file with a TypeError.
+    const name = schema.objects.columns[ruleHeader]?.name ?? ruleHeader
     return {
       name,
       requirement: getRequirement(rule as ColumnRule, ruleHeader),

--- a/src/validators/filenameIdentify.ts
+++ b/src/validators/filenameIdentify.ts
@@ -17,6 +17,7 @@ import type { GenericSchema } from '../types/schema.ts'
 import type { BIDSContext } from '../schema/context.ts'
 import type { CheckFunction } from '../types/check.ts'
 import { lookupEntityLiteral } from './filenameValidate.ts'
+import { hasStimuliCatalog } from './internal/stimuliCatalog.ts'
 
 const CHECKS: CheckFunction[] = [
   findRuleMatches,
@@ -133,12 +134,11 @@ export function hasMatch(schema, context) {
     context.filenameRules.length === 0 &&
     context.file.path !== '/.bidsignore'
   ) {
-    // Legacy /stimuli directories (no stimuli.tsv catalog at the /stimuli
-    // root) are free-form; only catalog-organized stimuli directories
+    // Legacy /stimuli directories (no stimuli.tsv catalog anywhere in the
+    // hierarchy) are free-form; only catalog-organized stimuli directories
     // enforce the stimulus naming rules.
     if (context.path.startsWith('/stimuli/')) {
-      const stimDir = context.dataset.tree.get('stimuli')
-      if (!stimDir?.files?.some((f) => f.name === 'stimuli.tsv')) {
+      if (!hasStimuliCatalog(context.dataset.tree.get('stimuli'))) {
         return
       }
     }

--- a/src/validators/filenameIdentify.ts
+++ b/src/validators/filenameIdentify.ts
@@ -51,6 +51,12 @@ export function findDirRuleMatches(schema, context) {
         context.filenameRules.push(path)
         break
       }
+      // Directories explicitly marked non-opaque (e.g. stimuli) may contain
+      // arbitrary subdirectories to organize their files.
+      if (node.opaque === false && context.file.path.startsWith(`/${node.name}/`)) {
+        context.filenameRules.push(path)
+        break
+      }
     }
     if ('entity' in node) {
       const entityDef = schemaEntities[node.entity]
@@ -127,6 +133,15 @@ export function hasMatch(schema, context) {
     context.filenameRules.length === 0 &&
     context.file.path !== '/.bidsignore'
   ) {
+    // Legacy /stimuli directories (no stimuli.tsv catalog at the /stimuli
+    // root) are free-form; only catalog-organized stimuli directories
+    // enforce the stimulus naming rules.
+    if (context.path.startsWith('/stimuli/')) {
+      const stimDir = context.dataset.tree.get('stimuli')
+      if (!stimDir?.files?.some((f) => f.name === 'stimuli.tsv')) {
+        return
+      }
+    }
     context.dataset.issues.add({
       code: 'NOT_INCLUDED',
       location: context.path,

--- a/src/validators/internal/stimuliCatalog.test.ts
+++ b/src/validators/internal/stimuliCatalog.test.ts
@@ -1,0 +1,31 @@
+import { assertEquals } from '@std/assert'
+import { pathsToTree } from '../../files/filetree.test.ts'
+import type { FileTree } from '../../types/filetree.ts'
+import { hasStimuliCatalog } from './stimuliCatalog.ts'
+
+function stimTree(paths: string[]): FileTree | undefined {
+  return pathsToTree(paths).get('stimuli') as FileTree | undefined
+}
+
+Deno.test('hasStimuliCatalog', async (t) => {
+  await t.step('false for a legacy free-form stimuli directory', () => {
+    assertEquals(hasStimuliCatalog(stimTree(['/stimuli/left_hand.png'])), false)
+  })
+  await t.step('false for a missing stimuli directory', () => {
+    assertEquals(hasStimuliCatalog(undefined), false)
+  })
+  await t.step('true for a root catalog', () => {
+    assertEquals(
+      hasStimuliCatalog(stimTree(['/stimuli/stimuli.tsv', '/stimuli/stim-a_image.png'])),
+      true,
+    )
+  })
+  await t.step('true for a subdirectory catalog without a root catalog', () => {
+    assertEquals(
+      hasStimuliCatalog(
+        stimTree(['/stimuli/faces/stimuli.tsv', '/stimuli/faces/stim-a_image.png']),
+      ),
+      true,
+    )
+  })
+})

--- a/src/validators/internal/stimuliCatalog.ts
+++ b/src/validators/internal/stimuliCatalog.ts
@@ -1,0 +1,18 @@
+import type { FileTree } from '../../types/filetree.ts'
+
+/**
+ * A stimuli.tsv catalog anywhere under /stimuli indicates the BEP044
+ * stimulus organization ("catalog mode"). Legacy datasets have none, and
+ * their free-form /stimuli content is exempt from the stimulus naming and
+ * usage rules. Subdirectory catalogs count: a self-describing stimulus
+ * pack may carry its own stimuli.tsv without a dataset-wide root catalog.
+ */
+export function hasStimuliCatalog(tree: FileTree | undefined): boolean {
+  if (!tree) {
+    return false
+  }
+  if (tree.files.some((f) => f.name === 'stimuli.tsv')) {
+    return true
+  }
+  return tree.directories.some((dir) => hasStimuliCatalog(dir))
+}

--- a/src/validators/internal/unusedFile.ts
+++ b/src/validators/internal/unusedFile.ts
@@ -25,8 +25,15 @@ export function unusedStimulus(
   dsContext: BIDSContextDataset,
 ): void {
   const stimDir = dsContext.tree.get('stimuli') as FileTree
+  // A stimuli.tsv at the /stimuli root indicates the BEP044 organization:
+  // stimulus usage is tracked through stim_id and the stimuli.tsv catalog
+  // rather than direct stim_file path references, so catalog-managed files
+  // (stim-* entity files and the catalog tables) are not "unused".
+  const catalogMode = stimDir?.files?.some((f) => f.name === 'stimuli.tsv')
+  const catalogFile = (name: string) =>
+    /^stim-/.test(name) || /^(stimuli|annotations)\.(tsv|json)$/.test(name)
   const unusedStimuli = [...walkFileTree(stimDir, dsContext)].filter((stimulus) =>
-    !stimulus.viewed
+    !stimulus.viewed && !(catalogMode && catalogFile(stimulus.name))
   )
   if (unusedStimuli.length) {
     dsContext.issues.add({ code: 'UNUSED_STIMULUS', affects: unusedStimuli.map((s) => s.path) })

--- a/src/validators/internal/unusedFile.ts
+++ b/src/validators/internal/unusedFile.ts
@@ -1,6 +1,7 @@
 import type { GenericSchema } from '../../types/schema.ts'
 import type { BIDSFile, FileTree } from '../../types/filetree.ts'
 import type { BIDSContextDataset } from '../../schema/context.ts'
+import { hasStimuliCatalog } from './stimuliCatalog.ts'
 
 function* walkFileTree(fileTree: FileTree, dsContext: BIDSContextDataset): Generator<BIDSFile> {
   if (!fileTree) {
@@ -25,11 +26,11 @@ export function unusedStimulus(
   dsContext: BIDSContextDataset,
 ): void {
   const stimDir = dsContext.tree.get('stimuli') as FileTree
-  // A stimuli.tsv at the /stimuli root indicates the BEP044 organization:
-  // stimulus usage is tracked through stim_id and the stimuli.tsv catalog
-  // rather than direct stim_file path references, so catalog-managed files
-  // (stim-* entity files and the catalog tables) are not "unused".
-  const catalogMode = stimDir?.files?.some((f) => f.name === 'stimuli.tsv')
+  // In catalog mode (BEP044), stimulus usage is tracked through stim_id and
+  // the stimuli.tsv catalogs rather than direct stim_file path references,
+  // so catalog-managed files (stim-* entity files and the catalog tables)
+  // are not "unused".
+  const catalogMode = hasStimuliCatalog(stimDir)
   const catalogFile = (name: string) =>
     /^stim-/.test(name) || /^(stimuli|annotations)\.(tsv|json)$/.test(name)
   const unusedStimuli = [...walkFileTree(stimDir, dsContext)].filter((stimulus) =>


### PR DESCRIPTION
Companion to bids-standard/bids-specification#2022 (BEP044, Stim-BIDS). Draft until the BEP settles.

- Stop ignoring `/stimuli`; legacy free-form stimuli directories stay exempt (rules only apply when a `stimuli.tsv` catalog exists anywhere under `/stimuli`)
- Allow subdirectories of schema directories marked `opaque: false`
- Make `UNUSED_STIMULUS` recognize catalog-tracked stimuli
- Guard `evalInitialColumns` against unknown column keys (previously an uncaught TypeError silently skipped all rule evaluation for the file)

Tested with `deno test -A src` plus end-to-end validation of a new BEP044 example, legacy `eeg_matchingpennies`, and synthetic good/bad datasets against the BEP044 schema.