### PR TITLE
fix: Separately catch HED IssueError throws from file creation

### DIFF
--- a/changelog.d/20260904_093550_happy5214_hed_issue_error_catches.md
+++ b/changelog.d/20260904_093550_happy5214_hed_issue_error_catches.md
@@ -1,0 +1,50 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Added
+
+- A bullet item for the Added category.
+
+-->
+
+### Changed
+
+- Issues from HED file construction are now caught separately to provide more useful messages.
+  Previously, they were caught by the default handler and displayed as internal HED errors.
+
+
+<!--
+### Fixed
+
+- A bullet item for the Fixed category.
+
+-->
+<!--
+### Deprecated
+
+- A bullet item for the Deprecated category.
+
+-->
+<!--
+### Removed
+
+- A bullet item for the Removed category.
+
+-->
+<!--
+### Security
+
+- A bullet item for the Security category.
+
+-->
+<!--
+### Infrastructure
+
+- A bullet item for the Infrastructure category.
+
+-->

--- a/src/validators/hed.ts
+++ b/src/validators/hed.ts
@@ -76,12 +76,29 @@ export async function hedValidate(
 
   try {
     const hedValidator = await import('@hed/validator')
-
     let file
-    if (context.extension === '.tsv') {
-      file = buildHedTsvFile(context, hedValidator)
-    } else {
-      file = buildHedSidecarFile(context, hedValidator)
+
+    try {
+      if (context.extension === '.tsv') {
+        file = buildHedTsvFile(context, hedValidator)
+      } else {
+        file = buildHedSidecarFile(context, hedValidator)
+      }
+    } catch (error) {
+      let issueError: Error
+      if (error instanceof Error) {
+        issueError = error
+      } else {
+        issueError = new Error('unknown error')
+      }
+      const issues = hedValidator.BidsHedIssue.fromHedIssues(
+        issueError,
+        context.file,
+      )
+      for (const issue of issues) {
+        context.dataset.issues.add(issue)
+      }
+      return
     }
 
     const hedValidationIssues = await setHedSchemas(context.dataset, hedValidator)


### PR DESCRIPTION
Thrown `IssueError`s from HED file constructors were being caught by the general internal error catch, leading to unhelpful diagnostics. This adds an inner `try`-`catch` to separately generate useful BIDS issues for these (unwrapped) issues and return early.

Bug: #444