### PR TITLE
feat: Render logging arguments, log failures for lookups in git(-annex)

### DIFF
--- a/changelog.d/20260910_101348_markiewicz_logging.md
+++ b/changelog.d/20260910_101348_markiewicz_logging.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Improved logging formatter to provide more useful context.

--- a/src/files/git.ts
+++ b/src/files/git.ts
@@ -9,6 +9,7 @@ import { default as git, TREE } from 'isomorphic-git'
 import type { WalkerEntry } from 'isomorphic-git'
 import fs from 'node:fs'
 import { join } from '@std/path'
+import { logger } from '../utils/logger.ts'
 import {
   BIDSFile,
   type FileOpener,
@@ -155,8 +156,9 @@ export class AnnexedGitFileOpener implements FileOpener {
         const fileInfo = await Deno.stat(hashDirLowerPath)
         this.#delegate = new FsFileOpener(hashDirLowerPath, fileInfo)
         return this.#delegate
-      } catch {
+      } catch (e) {
         // Local object not present; fall through to remote resolution
+        logger.info(`Annexed file ${this.#key} not found in local annex object store`, e)
       }
     }
 
@@ -165,8 +167,9 @@ export class AnnexedGitFileOpener implements FileOpener {
       const { url } = await resolveAnnexedFile(this.#key, this.#preferredRemote, this.#gitOptions)
       this.#delegate = new HTTPOpener(url, this.size)
       return this.#delegate
-    } catch {
+    } catch (e) {
       // No accessible remote; fall through to null opener
+      logger.info(`Annexed file ${this.#key} not found in any accessible remote`, e)
     }
 
     // 3. Content unavailable

--- a/src/files/gitResolver.ts
+++ b/src/files/gitResolver.ts
@@ -22,6 +22,7 @@ import type { SymlinkReason, UnresolvedLink } from '../types/filetree.ts'
 import { AnnexedGitFileOpener, GitFileOpener } from './git.ts'
 import type { FileIgnoreRules } from './ignore.ts'
 import { parseAnnexKey } from './repo.ts'
+import { logger } from '../utils/logger.ts'
 
 export interface GitOptions {
   fs: FsClient
@@ -88,7 +89,8 @@ async function readObjectAt(
       filepath,
       ...source.gitOptions,
     }) as ParsedObject
-  } catch {
+  } catch (e) {
+    logger.debug(`readObjectAt: failed to read ${filepath} at ${source.commitOid}`, e)
     return null
   }
 }

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from '@std/assert'
-import { parseStack } from './logger.ts'
+import { ConsoleHandler, getLogger, setup } from '@std/log'
+import { debugEnabled, parseStack } from './logger.ts'
 
 Deno.test('logger', async (t) => {
   await t.step('test stack trace behavior for regular invocation', () => {
@@ -47,5 +48,36 @@ called from validate() (defined at file:///bids-validator/src/validators/bids.ts
   })
   await t.step('Does not throw on empty stack', () => {
     assertEquals(parseStack(''), undefined)
+  })
+})
+
+Deno.test('DEBUG log level detection', async (t) => {
+  setup({
+    handlers: {
+      errorhandler: new ConsoleHandler('ERROR'),
+      debughandler: new ConsoleHandler('DEBUG'),
+    },
+    loggers: {
+      // No handler, not enabled
+      testLoggerA: { level: 'DEBUG', handlers: [] },
+      // Top level ERROR, not enabled
+      testLoggerB: { level: 'ERROR', handlers: ['debughandler'] },
+      // No handler at DEBUG, not enabled
+      testLoggerC: { level: 'DEBUG', handlers: ['errorhandler'] },
+      // Top level DEBUG, has handler at DEBUG, enabled
+      testLoggerD: { level: 'DEBUG', handlers: ['debughandler'] },
+    },
+  })
+  await t.step('debugEnabled returns false for logger with no handlers', () => {
+    assertEquals(debugEnabled(getLogger('testLoggerA')), false)
+  })
+  await t.step('debugEnabled returns false for logger at ERROR level', () => {
+    assertEquals(debugEnabled(getLogger('testLoggerB')), false)
+  })
+  await t.step('debugEnabled returns false for logger with handlers above DEBUG', () => {
+    assertEquals(debugEnabled(getLogger('testLoggerC')), false)
+  })
+  await t.step('debugEnabled returns true for logger+handlers at DEBUG', () => {
+    assertEquals(debugEnabled(getLogger('testLoggerD')), true)
   })
 })

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals } from '@std/assert'
-import { ConsoleHandler, getLogger, setup } from '@std/log'
-import { debugEnabled, parseStack } from './logger.ts'
+import { assertEquals, assertFalse, assertStringIncludes } from '@std/assert'
+import { stripAnsiCode } from '@std/fmt/colors'
+import { ConsoleHandler, getLogger, type LevelName, setup } from '@std/log'
+import { debugEnabled, logger, parseStack, setupLogging } from './logger.ts'
 
 Deno.test('logger', async (t) => {
   await t.step('test stack trace behavior for regular invocation', () => {
@@ -80,4 +81,70 @@ Deno.test('DEBUG log level detection', async (t) => {
   await t.step('debugEnabled returns true for logger+handlers at DEBUG', () => {
     assertEquals(debugEnabled(getLogger('testLoggerD')), true)
   })
+})
+
+/**
+ * Configure logging at `level`, then capture everything the console handler
+ * writes while `emit` runs.
+ */
+function captureLogOutput(level: LevelName, emit: () => void): string[] {
+  setupLogging(level)
+  const lines: string[] = []
+  const original = console.log
+  console.log = (...args: unknown[]) => {
+    lines.push(stripAnsiCode(String(args[0])))
+  }
+  try {
+    emit()
+  } finally {
+    console.log = original
+  }
+  return lines
+}
+
+/**
+ * This is a regression test without a regression issue.
+ * An attempt at reducing calls to `getLogger()` by calling once at module scope
+ * resulted in all log actions occurring in the pre-configuration state.
+ * These tests ensure that our logger proxy always emits at the current state.
+ */
+Deno.test('log records reach a handler', async (t) => {
+  await t.step('debug records are emitted when configured at DEBUG', () => {
+    const lines = captureLogOutput('DEBUG', () => logger.debug('a debug record'))
+    assertFalse(lines.length === 0, 'no output reached the console handler')
+    assertStringIncludes(lines.join('\n'), 'DEBUG a debug record')
+  })
+
+  await t.step('caller location accompanies a debug record', () => {
+    const lines = captureLogOutput('DEBUG', () => logger.debug('a debug record'))
+    assertEquals(lines.length, 2)
+    assertStringIncludes(lines[0], 'Logger invoked at')
+    assertStringIncludes(lines[0], 'logger.test.ts')
+  })
+
+  await t.step('warnings are emitted when configured at WARN', () => {
+    const lines = captureLogOutput('WARN', () => logger.warn('a warning'))
+    assertEquals(lines, ['WARN a warning'])
+  })
+
+  await t.step('errors are emitted, and lower levels filtered, at ERROR', () => {
+    const lines = captureLogOutput('ERROR', () => {
+      logger.debug('suppressed')
+      logger.info('suppressed')
+      logger.warn('suppressed')
+      logger.error('an error')
+    })
+    // Nothing below ERROR is emitted, and the caller-location line is gated off.
+    assertEquals(lines, ['ERROR an error'])
+  })
+
+  await t.step('every level reaches a handler when configured at DEBUG', () => {
+    for (const level of ['debug', 'info', 'warn', 'error', 'critical'] as const) {
+      const lines = captureLogOutput('DEBUG', () => logger[level](`${level} record`))
+      assertStringIncludes(lines.join('\n'), `${level} record`, `${level} did not reach a handler`)
+    }
+  })
+
+  // Leave the shared @std/log state quiet for any test file that runs later.
+  setup({ handlers: {}, loggers: { '@bids/validator': { level: 'NOTSET', handlers: [] } } })
 })

--- a/src/utils/logger.test.ts
+++ b/src/utils/logger.test.ts
@@ -1,7 +1,22 @@
 import { assertEquals, assertFalse, assertStringIncludes } from '@std/assert'
 import { stripAnsiCode } from '@std/fmt/colors'
-import { ConsoleHandler, getLogger, type LevelName, setup } from '@std/log'
-import { debugEnabled, logger, parseStack, setupLogging } from './logger.ts'
+import {
+  ConsoleHandler,
+  getLogger,
+  type LevelName,
+  type LogLevel,
+  LogLevels,
+  setup,
+} from '@std/log'
+import { LogRecord } from '@std/log/logger'
+import {
+  debugEnabled,
+  describeError,
+  formatter,
+  logger,
+  parseStack,
+  setupLogging,
+} from './logger.ts'
 
 Deno.test('logger', async (t) => {
   await t.step('test stack trace behavior for regular invocation', () => {
@@ -147,4 +162,184 @@ Deno.test('log records reach a handler', async (t) => {
 
   // Leave the shared @std/log state quiet for any test file that runs later.
   setup({ handlers: {}, loggers: { '@bids/validator': { level: 'NOTSET', handlers: [] } } })
+})
+
+Deno.test('describeError', async (t) => {
+  await t.step('an Error renders as name and message', () => {
+    assertEquals(describeError(new Error('plain failure')), 'Error: plain failure')
+    assertEquals(describeError(new TypeError('bad type')), 'TypeError: bad type')
+  })
+
+  await t.step('an OS error carries its code alongside the name', () => {
+    const osErr = Object.assign(new Error('No such file'), { name: 'NotFound', code: 'ENOENT' })
+    assertEquals(describeError(osErr), 'NotFound[ENOENT]: No such file')
+  })
+
+  await t.step('a cause chain is followed', () => {
+    assertEquals(
+      describeError(new Error('outer', { cause: new RangeError('inner') })),
+      'Error: outer; caused by RangeError: inner',
+    )
+  })
+
+  await t.step('a cause of any type is described in turn', () => {
+    // The cause crosses back into the object and primitive branches.
+    assertEquals(
+      describeError(new Error('outer', { cause: { code: 'JSON_INVALID' } })),
+      'Error: outer; caused by JSON_INVALID',
+    )
+    assertEquals(
+      describeError(new Error('outer', { cause: 'a string cause' })),
+      'Error: outer; caused by a string cause',
+    )
+  })
+
+  await t.step('an Issue object renders code, subCode, location and message', () => {
+    assertEquals(describeError({ code: 'JSON_INVALID' }), 'JSON_INVALID')
+    assertEquals(describeError({ code: 'FILE_READ', subCode: 'NotFound' }), 'FILE_READ/NotFound')
+    assertEquals(
+      describeError({ code: 'INVALID_GZIP', location: '/x.nii.gz' }),
+      'INVALID_GZIP (at /x.nii.gz)',
+    )
+    assertEquals(
+      describeError({ code: 'TSV_DUP', issueMessage: 'onset, onset' }),
+      'TSV_DUP (onset, onset)',
+    )
+    assertEquals(
+      describeError({
+        code: 'FILE_READ',
+        subCode: 'NotFound',
+        location: '/a.nii.gz',
+        issueMessage: 'dangling',
+      }),
+      'FILE_READ/NotFound (at /a.nii.gz; dangling)',
+    )
+  })
+
+  await t.step('an Issue nesting an exception under `message` recurses', () => {
+    // The shape thrown by files/streams.ts on a decode failure.
+    assertEquals(
+      describeError({ code: 'INVALID_FILE_ENCODING', message: new TypeError('bad') }),
+      'INVALID_FILE_ENCODING (from TypeError: bad)',
+    )
+  })
+
+  await t.step('non-string Issue fields are skipped', () => {
+    // `location` is not a string, so no detail accumulates and the bare code is returned.
+    assertEquals(describeError({ code: 'X', location: 42 }), 'X')
+  })
+
+  await t.step('an object without a code is inspected', () => {
+    assertEquals(describeError({ unexpected: true, n: 3 }), '{ unexpected: true, n: 3 }')
+    assertEquals(describeError([1, 2, 3]), '[ 1, 2, 3 ]')
+  })
+
+  await t.step('inspection degrades without Deno, as in the web bundle', () => {
+    const saved = globalThis.Deno
+    try {
+      // deno-lint-ignore no-explicit-any
+      delete (globalThis as any).Deno
+      assertEquals(describeError({ unexpected: true }), '[object Object]')
+    } finally {
+      // deno-lint-ignore no-explicit-any
+      ;(globalThis as any).Deno = saved
+    }
+  })
+
+  await t.step('non-objects are stringified', () => {
+    assertEquals(describeError('raw string'), 'raw string')
+    assertEquals(describeError(undefined), 'undefined')
+    assertEquals(describeError(null), 'null')
+    assertEquals(describeError(42), '42')
+    assertEquals(describeError(false), 'false')
+  })
+
+  await t.step('recursion is bounded to four levels by default', () => {
+    let err = new Error('L5')
+    for (let i = 4; i >= 0; i--) err = new Error(`L${i}`, { cause: err })
+    assertEquals(
+      describeError(err),
+      'Error: L0; caused by Error: L1; caused by Error: L2; caused by Error: L3; caused by ...',
+    )
+  })
+
+  await t.step('an exhausted depth budget short-circuits', () => {
+    assertEquals(describeError(new Error('x'), -1), '...')
+    assertEquals(
+      describeError(new Error('a', { cause: new Error('b') }), 0),
+      'Error: a; caused by ...',
+    )
+  })
+
+  await t.step('nested `message` recursion is bounded too', () => {
+    let deep: Record<string, unknown> = { code: 'L5' }
+    for (let i = 4; i >= 0; i--) deep = { code: `L${i}`, message: deep }
+    assertEquals(describeError(deep), 'L0 (from L1 (from L2 (from L3 (from ...))))')
+  })
+
+  await t.step('a self-referential `message` terminates', () => {
+    const cycle: Record<string, unknown> = { code: 'A' }
+    cycle.message = cycle
+    assertEquals(describeError(cycle), 'A (from A (from A (from A (from ...))))')
+  })
+
+  await t.step('an Issue whose `message` is an Error keeps that cause chain', () => {
+    assertEquals(
+      describeError({ code: 'TOP', message: new Error('e1', { cause: new Error('e2') }) }),
+      'TOP (from Error: e1; caused by Error: e2)',
+    )
+  })
+
+  await t.step('a self-referential cause terminates', () => {
+    const cycle = new Error('loop') as Error & { cause?: unknown }
+    cycle.cause = cycle
+    assertEquals(
+      describeError(cycle),
+      'Error: loop; caused by Error: loop; caused by Error: loop; caused by Error: loop; caused by ...',
+    )
+  })
+})
+
+Deno.test('formatter', async (t) => {
+  const record = (msg: string, args: unknown[], level: LogLevel = LogLevels.DEBUG) =>
+    new LogRecord({ msg, args, level, loggerName: '@bids/validator' })
+
+  await t.step('a record without args renders the message alone', () => {
+    assertEquals(
+      formatter(record('Performing file-level validation...', [])),
+      'DEBUG Performing file-level validation...',
+    )
+  })
+
+  await t.step('a single arg is described and appended', () => {
+    assertEquals(
+      formatter(record('Error parsing gzip header', [{
+        code: 'INVALID_GZIP',
+        location: '/x.nii.gz',
+      }])),
+      'DEBUG Error parsing gzip header: INVALID_GZIP (at /x.nii.gz)',
+    )
+    assertEquals(
+      formatter(record('Failed to fetch schema', [new TypeError('connection reset')])),
+      'DEBUG Failed to fetch schema: TypeError: connection reset',
+    )
+  })
+
+  await t.step('multiple args are joined', () => {
+    assertEquals(
+      formatter(record('Fallback taken', [{ code: 'A' }, 'extra note'])),
+      'DEBUG Fallback taken: A; extra note',
+    )
+    assertEquals(
+      formatter(record('Fallback taken', [{ code: 'A' }, { code: 'B' }, 7])),
+      'DEBUG Fallback taken: A; B; 7',
+    )
+  })
+
+  await t.step('the level name prefixes the line', () => {
+    assertEquals(
+      formatter(record('a warning', [{ code: 'Z' }], LogLevels.WARN)),
+      'WARN a warning: Z',
+    )
+  })
 })

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,12 @@
-import { ConsoleHandler, getLogger, type LevelName, type Logger, LogLevels, setup } from '@std/log'
+import {
+  ConsoleHandler,
+  getLogger,
+  type LevelName,
+  type Logger,
+  LogLevels,
+  type LogRecord,
+  setup,
+} from '@std/log'
 
 /**
  * Setup a console logger used with the --debug flag
@@ -6,7 +14,7 @@ import { ConsoleHandler, getLogger, type LevelName, type Logger, LogLevels, setu
 export function setupLogging(level: LevelName) {
   setup({
     handlers: {
-      console: new ConsoleHandler(level),
+      console: new ConsoleHandler(level, { formatter }),
     },
 
     loggers: {
@@ -16,6 +24,45 @@ export function setupLogging(level: LevelName) {
       },
     },
   })
+}
+
+function inspect(value: object): string {
+  return typeof Deno !== 'undefined'
+    ? Deno.inspect(value, { depth: 1, compact: true, colors: false })
+    : String(value)
+}
+
+export function describeError(err: unknown, depth = 3): string {
+  if (depth < 0) return '...'
+  // Normal JS errors, follow cause chain
+  if (err instanceof Error) {
+    // OS Errors have code
+    const code = (err as { code?: string }).code
+    const self = `${code ? `${err.name}[${code}]` : err.name}: ${err.message}`
+    const cause = (err as { cause?: unknown }).cause
+    return cause === undefined ? self : `${self}; caused by ${describeError(cause, depth - 1)}`
+  }
+  if (err && typeof err === 'object') {
+    const o = err as Record<string, unknown>
+    // If validator issues are swallowed, provide detail
+    if (typeof o.code === 'string') {
+      const head = typeof o.subCode === 'string' ? `${o.code}/${o.subCode}` : o.code
+      const detail: string[] = []
+      if (typeof o.location === 'string') detail.push(`at ${o.location}`)
+      if (typeof o.issueMessage === 'string') detail.push(o.issueMessage)
+      if (o.message !== undefined) detail.push(`from ${describeError(o.message, depth - 1)}`)
+      return detail.length ? `${head} (${detail.join('; ')})` : head
+    }
+    // Other objects
+    return inspect(err)
+  }
+  return String(err)
+}
+
+export function formatter(record: LogRecord): string {
+  const head = `${record.levelName} ${record.msg}`
+  if (record.args.length === 0) return head
+  return `${head}: ${record.args.map((arg) => describeError(arg)).join('; ')}`
 }
 
 export function parseStack(stack: string): string | undefined {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -41,9 +41,8 @@ export function debugEnabled(logger: Logger): boolean {
     logger.handlers.some((handler) => handler.level <= LogLevels.DEBUG)
 }
 
-const loggerProxyHandler = {
-  // deno-lint-ignore no-explicit-any
-  get: function (_: any, prop: keyof Logger) {
+const loggerProxyHandler: ProxyHandler<Logger> = {
+  get: function (_: Logger, prop: keyof Logger) {
     const logger = getLogger('@bids/validator')
     if (debugEnabled(logger)) {
       const stack = new Error().stack

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import { ConsoleHandler, getLogger, type LevelName, type Logger, setup } from '@std/log'
+import { ConsoleHandler, getLogger, type LevelName, type Logger, LogLevels, setup } from '@std/log'
 
 /**
  * Setup a console logger used with the --debug flag
@@ -33,14 +33,24 @@ export function parseStack(stack: string): string | undefined {
   }
 }
 
+/**
+ * Test whether a DEBUG record emitted would reach at least one handler.
+ */
+export function debugEnabled(logger: Logger): boolean {
+  return logger.level <= LogLevels.DEBUG &&
+    logger.handlers.some((handler) => handler.level <= LogLevels.DEBUG)
+}
+
 const loggerProxyHandler = {
   // deno-lint-ignore no-explicit-any
   get: function (_: any, prop: keyof Logger) {
     const logger = getLogger('@bids/validator')
-    const stack = new Error().stack
-    if (stack) {
-      const callerLocation = parseStack(stack) ?? '<unknown>'
-      logger.debug(`Logger invoked at "${callerLocation}"`)
+    if (debugEnabled(logger)) {
+      const stack = new Error().stack
+      if (stack) {
+        const callerLocation = parseStack(stack) ?? '<unknown>'
+        logger.debug(`Logger invoked at "${callerLocation}"`)
+      }
     }
     const logFunc = logger[prop] as typeof logger.warn
     return logFunc.bind(logger)


### PR DESCRIPTION
We have a confusing situation where NIfTI headers fetched from S3 are unreadable on one system, but not another. The failures result in silent fallbacks that make the failed fetch act like an empty file, which is what we intended (failures should be issues, not crashes).

However, we don't have any logging that can help us understand what the specific failure is. I went to see how we're currently logging, and it's a bit inconsistent. One thing that came up is that we have situations where we do `logger.debug('Error parsing gzip header', error)`, but the `error` is not rendered in the logs.

This PR does the following:

1) Disables the caller location DEBUG log if there isn't a DEBUG handler. This avoids a stack reconstruction on every logging call unless we're at DEBUG.
2) Annotates loggerProxyHandler, which would have allowed the type checker to tell me that I should use `logger.debug()` instead of `logger.DEBUG()`, instead of wasting time the way I did.
3) Adds tests that would have identified that I broke logging by calling `getLogger()` once at the module level. (I thought the logger object would be a constant whose behavior was modified at configuration, rather than a fresh object derived from the current configuration.)
4) Adds a formatter so that `logger.debug('Error parsing gzip header', error)` does render the error.
5) Adds some logging for the fall-through behavior that motivated this PR in the first place.